### PR TITLE
fix for PHP Notice

### DIFF
--- a/fof/controller/controller.php
+++ b/fof/controller/controller.php
@@ -2098,7 +2098,7 @@ class FOFController extends JObject
 		$classPrefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
 		$viewType = preg_replace('/[^A-Z0-9_]/i', '', $type);
 
-		if (!empty($config['input']))
+		if (array_key_exists('input', $config))
 		{
 			if (($config['input'] instanceof FOFInput))
 			{


### PR DESCRIPTION
When creating a view, (and not passing a $config array) I was getting a PHP Notice: Undefined index: input in .../joomla3/libraries/fof/controller/controller.php on line 2101
