### PR TITLE
setting the view with nothing doesn't makes sense

### DIFF
--- a/fof/dispatcher/dispatcher.php
+++ b/fof/dispatcher/dispatcher.php
@@ -133,7 +133,12 @@ class FOFDispatcher extends JObject
 		$config['option'] = !is_null($option) ? $option : $input->getCmd('option', 'com_foobar');
 		$config['view'] = !is_null($view) ? $view : $input->getCmd('view', '');
 		$input->set('option', $config['option']);
-		$input->set('view', $config['view']);
+
+		if (!empty($config['view']))
+		{
+			$input->set('view', $config['view']);
+		}
+
 		$config['input'] = $input;
 
 		$className = ucfirst(str_replace('com_', '', $config['option'])) . 'Dispatcher';


### PR DESCRIPTION
if you do a $input->set('view', $config['view']) when $config['view'] is empty then the public $defaultView = 'items' in the dispatcher hasn't an effect. I have found this as I did a vanilla installation of fof and todo. If I click on the menu for todo I end in a add screen with a broken form. After some debugging I have seen that this code let it fail finally:

```
    // Get the default values for the component and view names
    $this->component = $this->input->getCmd('option', 'com_foobar');
```

*1      $this->view = $this->input->getCmd('view', $this->defaultView);

```
    // Load the component's fof.xml configuration file
    $configProvider = new FOFConfigProvider;
```

*2      $this->defaultView = $configProvider->get($this->component . '.dispatcher.default_view', 'cpanel');

*3      if (empty($this->view))
        {
            $this->view = $this->defaultView;
        }

*1 $this->view will be set with "", because view is set; $this->defaultView == 'items' at this point

*2 $this->defaultView = 'cpanel'

*3 empty($this->view) == true

--> $this->view = 'cpanel' # Winner
