### PR TITLE
avoid 'empty notice' if no 'as alias' in joined query

### DIFF
--- a/fof/table/table.php
+++ b/fof/table/table.php
@@ -1839,7 +1839,7 @@ class FOFTable extends JObject
 			{
 				// Is there any alias for this column?
 				preg_match('#\sas\s`?\w+`?#i', $t_field, $match);
-				$alias = $match[0];
+				$alias = empty($match) ? '' : $match[0];
 				$alias = preg_replace('#\sas\s?#i', '', $alias);
 
 				// Grab the "standard" name


### PR DESCRIPTION
when using a joined query, there is a notice in FOFTable::normalizeSelectFields

line 1842 
    $alias = $match[0];

shouldn't be safer ? with 

```
$alias = empty($match) ? '' : $match[0];
```
