### PR TITLE
Fixed warning creating default object from empty value

### DIFF
--- a/fof/form/field/list.php
+++ b/fof/form/field/list.php
@@ -247,6 +247,7 @@ class FOFFormFieldList extends JFormFieldList implements FOFFormField
 		{
 			$name = JText::alt(trim((string) $option), preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname));
 
+			$sortoptions[$i] = new stdClass();
 			$sortOptions[$i]->option = $option;
 			$sortOptions[$i]->value = $option['value'];
 			$sortOptions[$i]->name = $name;


### PR DESCRIPTION
This is the fix for the warnings that appear when FOFFormFieldList::getOptions() is run.
