### PR TITLE
Fixed typo in array name

### DIFF
--- a/fof/form/field/list.php
+++ b/fof/form/field/list.php
@@ -247,7 +247,7 @@ class FOFFormFieldList extends JFormFieldList implements FOFFormField
 		{
 			$name = JText::alt(trim((string) $option), preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname));
 
-			$sortoptions[$i] = new stdClass();
+			$sortOptions[$i] = new stdClass();
 			$sortOptions[$i]->option = $option;
 			$sortOptions[$i]->value = $option['value'];
 			$sortOptions[$i]->name = $name;


### PR DESCRIPTION
There is a typo in the array name of an earlier PR. This is fixed in this one.
