### PR TITLE
Fixed incorrect markup if form-validate is used

### DIFF
--- a/fof/render/joomla.php
+++ b/fof/render/joomla.php
@@ -335,7 +335,7 @@ class FOFRenderJoomla extends FOFRenderAbstract
 		{
 			JHTML::_('behavior.framework', true);
 			JHTML::_('behavior.formvalidation');
-			$class = ' class="form-validate"';
+			$class = 'form-validate ';
 			$this->loadValidationScript($form);
 		}
 


### PR DESCRIPTION
When the validate is set to true on a form XML it rendered:

``` html
 class=" class="form-validate"" 
```

creating incorrect markup. This change fixes the incorrect markup.
