### PR TITLE
Ignored filtering for boolean fields setted as "0"

### DIFF
--- a/fof/model/field.php
+++ b/fof/model/field.php
@@ -71,7 +71,7 @@ abstract class FOFModelField
 	 */
 	public function isEmpty($value)
 	{
-		return ($value === $this->null_value) || ('' === $value);
+		return ($value === $this->null_value) || ($value === '');
 	}
 
 	/**


### PR DESCRIPTION
The `isEmpty` method used the `empty` PHP function, which returns `true` when is used on a 0 (integer) or on a "0" (string); you can check the official documentation [here](http://php.net/manual/en/function.empty.php).
