### PR TITLE
Fixed bug in strapper.php causing non-translatable filter labels

### DIFF
--- a/fof/render/strapper.php
+++ b/fof/render/strapper.php
@@ -544,7 +544,7 @@ ENDJS;
 					{
 						$filter_html .= '<div class="filter-search btn-group pull-left">' . "\n";
 						$filter_html .= "\t" . '<label for="title" class="element-invisible">';
-						$filter_html .= $headerField->label;
+						$filter_html .= JText::_($headerField->label);
 						$filter_html .= "</label>\n";
 						$filter_html .= "\t$filter\n";
 						$filter_html .= "</div>\n";


### PR DESCRIPTION
The field label isn't pushed through JText before the output when used in a filter. Fixed it with this slight change.
