### PR TITLE
Fixed scope collision (form/field/model.php)

### DIFF
--- a/fof/form/field/model.php
+++ b/fof/form/field/model.php
@@ -238,10 +238,10 @@ class FOFFormFieldModel extends FOFFormFieldList implements FOFFormField
 				continue;
 			}
 
-			$key = (string) $stateoption['key'];
-			$value = (string) $stateoption;
+			$statusKey = (string) $stateoption['key'];
+			$statusValue = (string) $stateoption;
 
-			$model->setState($key, $value);
+			$model->setState($statusKey, $statusValue);
 		}
 
 		// Set the query and get the result list.


### PR DESCRIPTION
Fixed scope collision between variables `$key` and `$value`.
