### PR TITLE
Fixed scope collision (form/header/model.php)

### DIFF
--- a/fof/form/header/model.php
+++ b/fof/form/header/model.php
@@ -70,10 +70,10 @@ class FOFFormHeaderModel extends FOFFormHeaderFieldselectable
 				continue;
 			}
 
-			$key = (string) $stateoption['key'];
-			$value = (string) $stateoption;
+			$statusKey = (string) $stateoption['key'];
+			$statusValue = (string) $stateoption;
 
-			$model->setState($key, $value);
+			$model->setState($statusKey, $statusValue);
 		}
 
 		// Set the query and get the result list.


### PR DESCRIPTION
Fixed scope collision between variables `$key` and `$value`.
