### PR TITLE
Fixed variables scope collision

### DIFF
--- a/fof/form/field/model.php
+++ b/fof/form/field/model.php
@@ -240,10 +240,10 @@ class FOFFormFieldModel extends FOFFormFieldList implements FOFFormField
 				continue;
 			}
 
-			$key = (string) $stateoption['key'];
-			$value = (string) $stateoption;
+			$stateKey = (string) $stateoption['key'];
+			$stateValue = (string) $stateoption;
 
-			$model->setState($key, $value);
+			$model->setState($stateKey, $stateValue);
 		}
 
 		// Set the query and get the result list.


### PR DESCRIPTION
Fixed scope collision for variables `$key` and `$value`.
