### PR TITLE
Fixed variables scope collision

### DIFF
--- a/fof/form/header/model.php
+++ b/fof/form/header/model.php
@@ -70,10 +70,10 @@ class FOFFormHeaderModel extends FOFFormHeaderFieldselectable
 				continue;
 			}
 
-			$key = (string) $stateoption['key'];
-			$value = (string) $stateoption;
+			$stateKey = (string) $stateoption['key'];
+			$stateValue = (string) $stateoption;
 
-			$model->setState($key, $value);
+			$model->setState($stateKey, $stateValue);
 		}
 
 		// Set the query and get the result list.


### PR DESCRIPTION
Fixed scope collision for variables `$key` and `$value`.
