### PR TITLE
Ability to use custom class for control-group of forms

### DIFF
--- a/fof/render/strapper.php
+++ b/fof/render/strapper.php
@@ -1000,6 +1000,7 @@ ENDJS;
 			{
 				$required	 = $field->required;
 				$labelClass	 = $field->labelClass;
+				$groupClass	 = $form->getFieldAttribute($field->fieldname, 'groupclass', '', $field->group);
 
 				// Auto-generate label and description if needed
 				// Field label
@@ -1048,7 +1049,7 @@ ENDJS;
 				}
 				else
 				{
-					$html .= "\t\t\t" . '<div class="control-group">' . PHP_EOL;
+					$html .= "\t\t\t" . '<div class="control-group ' . $groupClass . '">' . PHP_EOL;
 					$html .= "\t\t\t\t" . '<label class="control-label ' . $labelClass . '" for="' . $field->id . '">' . PHP_EOL;
 					$html .= "\t\t\t\t" . JText::_($title) . PHP_EOL;
 


### PR DESCRIPTION
This PR gives you the ability to use a custom class for the control-group div. This way you could e.g. disable and hide fields with JavaScript. Currently I only implement it for FOFRenderStrapper->renderFormRaw(). I'm not sure how to test FOFRenderJoomla (tips?), but I can implement it for that as well if you'd like.
