### PR TITLE
gh-153 Don't (un)serialize the database

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -1271,6 +1271,8 @@ class FOFModel extends JObject
 					$session = JFactory::getSession();
 					$tableprops = $table->getProperties(true);
 					unset($tableprops['input']);
+					unset($tableprops['config']['db']);
+					unset($tableprops['config']['dbo']);
 					$hash = $this->getHash() . 'savedata';
 					$session->set($hash, serialize($tableprops));
 				}


### PR DESCRIPTION
Yeaha!!! I think this is the correct fix, see also the comment of the commit. It works for me but please verify that I'm allowed to unset these variables. I did it like this PR: https://github.com/joomla/joomla-cms/pull/1040 Also note that there's another input property, maybe this also needs to be unset? <code>unset($tableprops['config']['input']);</code>
