### PR TITLE
Update .gitignore: build/bin wasn't ignored when it's a link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ refs/heads/staging
 build.xml
 antconfig.txt
 
-/build/bin/
+/build/bin
 
 /tests/environments/3.x/cache/
 /tests/environments/3.x/templates/fake_test_template


### PR DESCRIPTION
Sorry, overlooked this one.
