### PR TITLE
fixed repeatable URL classes

### DIFF
--- a/fof/form/field/url.php
+++ b/fof/form/field/url.php
@@ -109,7 +109,7 @@ class FOFFormFieldUrl extends JFormFieldUrl implements FOFFormField
 	public function getRepeatable()
 	{
 		// Initialise
-		$class             = '$this->id';
+		$class             = $this->id;
 		$show_link         = false;
 		$empty_replacement = '';
 


### PR DESCRIPTION
When using a Form, a (repeatable) URL field is generating incorrect class names.
