### PR TITLE
Unable to create a new entity with behaviour "private" (frontend)

### DIFF
--- a/fof/model/behavior/private.php
+++ b/fof/model/behavior/private.php
@@ -68,6 +68,12 @@ class FOFModelBehaviorPrivate extends FOFModelBehavior
 	{
 		if ($record instanceof FOFTable)
 		{
+			$keyName = $record->getKeyName();
+			if ($record->$keyName === null)
+			{
+				return;
+			}
+
 			$fieldName = $record->getColumnAlias('created_by');
 
 			// Make sure the field actually exists


### PR DESCRIPTION
The behavior ignores the fact that the FOFTable `$record` could be empty (i.e. a new record).

You can replicate that problem:
1. Define an entity with behavior `private`
2. Frontend login with a user with `core.create` permission for the entity
3. Try to access the entity's `add` task
4. You get an empty page, without any form
