### PR TITLE
Error is not being set in store function

### DIFF
--- a/fof/table/table.php
+++ b/fof/table/table.php
@@ -1205,6 +1205,7 @@ class FOFTable extends JObject implements JTableInterface
 
 		if ($result !== true)
 		{
+			$this->setError($this->_db->getErrorMsg());
 			return false;
 		}
 


### PR DESCRIPTION
If there's an error in store, the error is not set; and the controller shows an empty dialog.

This fix adds the error setting.

Thanks,
