### PR TITLE
FOFModel save with FOFForm and fieldsets

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -1205,13 +1205,12 @@ class FOFModel extends JObject
 		{
 			// Make sure that $allData has for any field a key
 			$fieldset = $form->getFieldset();
-			$keys = array_keys($fieldset);
 
-			foreach ($keys as $nfield)
+			foreach ($fieldset as $nfield => $fldset)
 			{
 				if (!array_key_exists($nfield, $allData))
 				{
-					$field = $form->getField($nfield);
+					$field = $form->getField($fldset->fieldname, $fldset->group);
 					$type  = strtolower($field->type);
 
 					switch ($type)
@@ -1229,6 +1228,7 @@ class FOFModel extends JObject
 
 			$serverside_validate = strtolower($form->getAttribute('serverside_validate'));
 
+			$validateResult = true;
 			if (in_array($serverside_validate, array('true', 'yes', '1', 'on')))
 			{
 				$validateResult = $this->validateForm($form, $allData);


### PR DESCRIPTION
Hi Nic,

I'm saving articles based on article.xml.

FOFForm works until it finds attribs/show_title.

In this case, FOFFormField has id=attribs_show_title.

When $form->getField is executed, it's returning no field with $form->getField('attribs_show_title');

So, the change submits $form->getField('show_title', 'attribs'); to get the right field.

Also, validateResult is initialized with true to avoid a warning.

Regards,
Anibal
