### PR TITLE
Add Joomla formatter for FOFLess

### DIFF
--- a/fof/less/formatter/joomla.php
+++ b/fof/less/formatter/joomla.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package    FrameworkOnFramework
+ * @copyright  Copyright (C) 2010 - 2012 Akeeba Ltd. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+// Protect from unauthorized access
+defined('_JEXEC') or die;
+
+/**
+ * This class is taken verbatim from:
+ *
+ * lessphp v0.3.8
+ * http://leafo.net/lessphp
+ *
+ * LESS css compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2012, Leaf Corcoran <leafot@gmail.com>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @package  FrameworkOnFramework
+ * @since    2.1
+ */
+class FOFLessFormatterJoomla extends FOFLessFormatterClassic
+{
+	public $disableSingle = true;
+
+	public $breakSelectors = true;
+
+	public $assignSeparator = ": ";
+
+	public $selectorSeparator = ",";
+
+	public $indentChar = "\t";
+}


### PR DESCRIPTION
This PR adds the Joomla formatter we've been using during 3.x for our LESS compiling.  This'll let us dump the now duplicated lessc library out of our build folder and just use FOFLess there.
