### PR TITLE
Unable to override a model's behavior

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -367,7 +367,7 @@ class FOFModel extends JObject
 		}
 
 		// First look for ComponentnameModelViewnameBehaviorName (e.g. FoobarModelItemsBehaviorFilter)
-		$behaviorClass = ucfirst($this->option) . 'Model' . FOFInflector::pluralize($this->name) . 'Behavior' . ucfirst(strtolower($name));
+		$behaviorClass = get_class($this) . 'Behavior' . ucfirst(strtolower($name));
 
 		if (class_exists($behaviorClass))
 		{


### PR DESCRIPTION
The current code searches for the class `Com_foobarModelfoobarBehaviorPrivate` instead of `FoobarModelItemsBehaviorPrivate`.

This happens because `$this->option` contains the full component name ("com_foobar") while `$this->name` contains its unprefixed name ("foobar").
