### PR TITLE
Show which form file could not be loaded.

### DIFF
--- a/fof/form/form.php
+++ b/fof/form/form.php
@@ -77,7 +77,7 @@ class FOFForm extends JForm
 			{
 				if ($forms[$name]->loadFile($data, $replace, $xpath) == false)
 				{
-					throw new RuntimeException('FOFForm::getInstance could not load file');
+					throw new RuntimeException('FOFForm::getInstance could not load file ' . $data . '.xml');
 				}
 			}
 		}


### PR DESCRIPTION
From time to time I get the message "FOFForm::getInstance could not load file" but since this view loads multiple forms it is never clear which one could not be loaded. Adding the name of the file FOF is trying to load will help understand where things go boogie.
