### PR TITLE
Added a small feature to the model behavior loading process

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -377,6 +377,17 @@ class FOFModel extends JObject
 			return true;
 		}
 
+		// Then look for ComponentnameModelBehaviorName (e.g. FoobarModelBehaviorFilter)
+		$option_name = str_replace('com_', '', $this->name);
+		$behaviorClass = ucfirst($option_name) . 'ModelBehavior' . ucfirst(strtolower($name));
+
+		if (class_exists($behaviorClass))
+		{
+			$behavior = new $behaviorClass($this->modelDispatcher, $config);
+
+			return true;
+		}
+
 		// Then look for FOFModelBehaviorName (e.g. FOFModelBehaviorFilter)
 		$behaviorClassAlt = 'FOFModelBehavior' . ucfirst(strtolower($name));
 


### PR DESCRIPTION
# Before

Before this pull request, when FOF was loading a behavior for a model, it would follow this workflow:

1) Search for **ComponentnameModelViewnameBehaviorName** (e.g. FoobarModelItemsBehaviorFilter)
2) Search for FOFModelBehaviorName (e.g. FOFModelBehaviorFilter)
# After

1) Search for **ComponentnameModelViewnameBehaviorName** (e.g. FoobarModelItemsBehaviorFilter)
2) Search for **ComponentnameModelBehaviorName** (e.g. FoobarModelBehaviorFilter)
3) Search for FOFModelBehaviorName (e.g. FOFModelBehaviorFilter)

I added a new class search, that doesn't include the view name, but only the component name. 
It makes sense that usually behaviors are shared across models, otherwise they would just stay in the single model class. That's why it should search for a more generic class name, and not one that depends on the model itself.

I left 2) since one single model may want to override a generic or component wide behavior
