### PR TITLE
Fix toolbar subtitle (J3.2.0) and use the same toolbar title format as J...

### DIFF
--- a/fof/toolbar/toolbar.php
+++ b/fof/toolbar/toolbar.php
@@ -346,7 +346,7 @@ class FOFToolbar
 		// Set toolbar title
 		$option = $this->input->getCmd('option', 'com_foobar');
 		$subtitle_key = strtoupper($option . '_TITLE_' . $this->input->getCmd('view', 'cpanel'));
-		JToolBarHelper::title(JText::_(strtoupper($option)) . ' &ndash; <small>' . JText::_($subtitle_key) . '</small>', str_replace('com_', '', $option));
+		JToolBarHelper::title(JText::_(strtoupper($option)) . ': ' . JText::_($subtitle_key), str_replace('com_', '', $option));
 
 		// Add toolbar buttons
 


### PR DESCRIPTION
...oomla core

The subtitle was gray in Joomla 3.2
