### PR TITLE
Use Y-m-d H:i:s date version format, so extension installers can notice newer FOF version on same day

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -51,7 +51,7 @@
 	
 	<target name="setup-properties" description="Set up version and build properties">
 		<!-- Initialize the git.date timestamp -->
-		<gitdate workingcopy="${dirs.root}" format="Y-m-d" propertyname="git.date" />
+		<gitdate workingcopy="${dirs.root}" format="Y-m-d H:i:s" propertyname="git.date" />
 
 		<!-- Initialize the version if it's not set -->
 		<if>


### PR DESCRIPTION
When a component is released on the same day with a newer FOF version, FOF is not installed. This is because _installFOF() of the component can't check for hours/minutes/seconds when that info is not given. This is fixed by using Y-m-d H:i:s in stead of Y-m-d. 

Test:
I tested it and installing works for me. If you update for the first time with a new FOF release, the installer script of the component detects FOF as an update. When you update it for the second time (with the same FOF version), the installer script of the component detects that it has been updated. No modifications for the component installer script were needed.

Of course, on Joomla 3.2.0 you should not install FOF at all. But I needed this for my (tiny) framework and submitted this PR for good measure. For FOF and Akeeba Strapper it has effect for < J3.2.

Cheers,
Jurian
