### PR TITLE
Close #225

### DIFF
--- a/fof/controller/controller.php
+++ b/fof/controller/controller.php
@@ -2815,11 +2815,14 @@ class FOFController extends JObject
 					if (FOFPlatform::getInstance()->authorise('core.edit.own', $asset))
 					{
 						$table = $this->getThisModel()->getTable();
+                        $table->load($id);
 
-						if ($table && isset($table->created_by))
+                        $created_by = $table->getColumnAlias('created_by');
+
+						if ($table && isset($table->$created_by))
 						{
 							// Now test the owner is the user.
-							$owner_id = (int) $table->created_by;
+							$owner_id = (int) $table->$created_by;
 
 							// If the owner matches 'me' then do the test.
 							if ($owner_id == FOFPlatform::getInstance()->getUser()->id)

--- a/fof/toolbar/toolbar.php
+++ b/fof/toolbar/toolbar.php
@@ -444,7 +444,7 @@ class FOFToolbar
 		JToolBarHelper::title(JText::_(strtoupper($option)) . ' &ndash; <small>' . JText::_($subtitle_key) . '</small>', $componentName);
 
 		// Set toolbar icons
-        if ($this->perms->edit)
+        if ($this->perms->edit || $this->perms->editown)
         {
             // Show the apply button only if I can edit the record, otherwise I'll return to the edit form and get a
             // 403 error since I can't do that

--- a/fof/view/raw.php
+++ b/fof/view/raw.php
@@ -77,10 +77,11 @@ class FOFViewRaw extends FOFView
 		{
 			$platform = FOFPlatform::getInstance();
 			$perms = (object) array(
-					'create'	 => $platform->authorise('core.create', $this->input->getCmd('option', 'com_foobar')),
-					'edit'		 => $platform->authorise('core.edit', $this->input->getCmd('option', 'com_foobar')),
-					'editstate'	 => $platform->authorise('core.edit.state', $this->input->getCmd('option', 'com_foobar')),
-					'delete'	 => $platform->authorise('core.delete', $this->input->getCmd('option', 'com_foobar')),
+					'create'	 => $platform->authorise('core.create'     , $this->input->getCmd('option', 'com_foobar')),
+					'edit'		 => $platform->authorise('core.edit'       , $this->input->getCmd('option', 'com_foobar')),
+					'editown'	 => $platform->authorise('core.edit.own'   , $this->input->getCmd('option', 'com_foobar')),
+					'editstate'	 => $platform->authorise('core.edit.state' , $this->input->getCmd('option', 'com_foobar')),
+					'delete'	 => $platform->authorise('core.delete'     , $this->input->getCmd('option', 'com_foobar')),
 			);
 			$this->assign('aclperms', $perms);
 			$this->perms = $perms;
@@ -232,7 +233,7 @@ class FOFViewRaw extends FOFView
         // This perms are used only for hestetic reasons (ie showing toolbar buttons), "real" checks
         // are made by the controller
         // It seems that I can't edit records, maybe I can edit only this one due asset tracking?
-		if (!$this->perms->edit)
+		if (!$this->perms->edit || !$this->perms->editown)
         {
             $model = $this->getModel();
 
@@ -244,7 +245,16 @@ class FOFViewRaw extends FOFView
                 if($table->isAssetsTracked())
                 {
                     $platform = FOFPlatform::getInstance();
-                    $this->perms->edit = $platform->authorise('core.edit', $table->getAssetName());
+
+                    if(!$this->perms->edit)
+                    {
+                        $this->perms->edit = $platform->authorise('core.edit', $table->getAssetName());
+                    }
+
+                    if(!$this->perms->editown)
+                    {
+                        $this->perms->editown = $platform->authorise('core.edit.own', $table->getAssetName());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Show “save” button if I can edit that single record, too
Fixed bug in controller:
    - table was not loaded before checking created_by field vs current user id
    - Column aliases were not honored
