### PR TITLE
Fix fatal error on time format

### DIFF
--- a/fof/form/field/calendar.php
+++ b/fof/form/field/calendar.php
@@ -113,8 +113,8 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 		// PHP date doesn't use percentages (%) for the format, but the calendar Javascript
 		// DOES use it (@see: calendar-uncompressed.js). Therefore we have to convert it.
 		$formatJS  = $format;
-		$formatPHP = str_replace('%', '', $formatJS);
-
+		$formatPHP = str_replace(array('%', 'H:M:S'), array('', 'H:i:s'), $formatJS);
+		
 		// Get some system objects.
 		$config = JFactory::getConfig();
 		$user = JFactory::getUser();


### PR DESCRIPTION
The original Joomla calendar form field supports the time format too. Since the JS time format is not the same as the PHP format just replacing the % fails into a fatal error. Replacing the JS time format with the PHP equivalent fixes this issue.
