### PR TITLE
Fix field labelclass on render

### DIFF
--- a/fof/render/joomla.php
+++ b/fof/render/joomla.php
@@ -263,7 +263,7 @@ class FOFRenderJoomla extends FOFRenderAbstract
 				{
 					$field->rowid	 = $i;
 					$field->item	 = $table_item;
-					$class			 = $field->labelClass ? 'class ="' . $field->labelClass . '"' : '';
+					$class			 = $field->labelclass ? 'class ="' . $field->labelclass . '"' : '';
 					$html .= "\t\t\t\t\t<td $class>" . $field->getRepeatable() . '</td>' . PHP_EOL;
 				}
 

--- a/fof/render/strapper.php
+++ b/fof/render/strapper.php
@@ -831,7 +831,7 @@ JS;
 				{
 					$field->rowid	 = $i;
 					$field->item	 = $table_item;
-					$class			 = $field->labelClass ? 'class ="' . $field->labelClass . '"' : '';
+					$class			 = $field->labelclass ? 'class ="' . $field->labelclass . '"' : '';
 					$html .= "\t\t\t\t\t<td $class>" . $field->getRepeatable() . '</td>' . PHP_EOL;
 				}
 
@@ -1042,7 +1042,7 @@ JS;
 			foreach ($fields as $field)
 			{
 				$required	 = $field->required;
-				$labelClass	 = $field->labelClass;
+				$labelClass	 = $field->labelclass;
 				$groupClass	 = $form->getFieldAttribute($field->fieldname, 'groupclass', '', $field->group);
 
 				// Auto-generate label and description if needed


### PR DESCRIPTION
The render (joomla and strapper) use camelCase for $field->labelClass. This can't work because Joomla doesn't.

joomla/form/field.php (line 273)

``` PHP
    protected $labelclass;
```
