### PR TITLE
load is returning true, even when the row is empty

### DIFF
--- a/fof/table/table.php
+++ b/fof/table/table.php
@@ -930,7 +930,7 @@ class FOFTable extends FOFUtilsObject implements JTableInterface
 		// Check that we have a result.
 		if (empty($row))
 		{
-			$result = true;
+			$result = false;
 
 			return $this->onAfterLoad($result);
 		}


### PR DESCRIPTION
Hi Nicholas,

Table load is returning true, even when the row is empty.

If there's no row, I think it should return false. 

Thanks,
Anibal
