### PR TITLE
Fixes the submenu dropdown parent active property

### DIFF
--- a/fof/toolbar/toolbar.php
+++ b/fof/toolbar/toolbar.php
@@ -541,6 +541,11 @@ class FOFToolbar
 
 			$parentElement['items'][] = $linkDefinition;
 			$parentElement['dropdown'] = true;
+			
+			if($active)
+			{
+				$parentElement['active'] = true;
+			}
 
 			$this->linkbar[$parent] = $parentElement;
 		}


### PR DESCRIPTION
When using renderer in classic mode, the submenu parent didn't have the 'active' attribute.
