### PR TITLE
~ Added btn-group to radio buttons of FOFFormFieldRadio

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ FOF 2.2.0
 ~ FOFModel::onBeforePreprocessForm explicitly passes the form object as reference. Please update your method signature to avoid PHP notices
 ~ FOFModel::onAfterPreprocessForm explicitly passes the form object as reference. Please update your method signature to avoid PHP notices
 ~ FOFModel::preprocessForm explicitly passes the form object as reference. Please update your method signature to avoid PHP notices
+~ Added btn-group to radio buttons of FOFFormFieldRadio
 # [LOW] Notice in render/strapper.php
 # [LOW] gh-246 Fix wrong singularize result for word "menus"
 # [LOW] gh-247 Grouped list field uses getOptions instead of getGroups, leading to a fatal error

--- a/fof/form/field/radio.php
+++ b/fof/form/field/radio.php
@@ -101,4 +101,55 @@ class FOFFormFieldRadio extends JFormFieldRadio implements FOFFormField
 			htmlspecialchars(FOFFormFieldList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}
+
+	/**
+	 * Method to get the radio button field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 */
+	protected function getInput()
+	{
+		$html = array();
+
+		// Initialize some field attributes.
+		$class     = !empty($this->class) ? ' class="radio btn-group ' . $this->class . '"' : ' class="radio btn-group"';
+		$required  = $this->required ? ' required aria-required="true"' : '';
+		$autofocus = $this->autofocus ? ' autofocus' : '';
+		$disabled  = $this->disabled ? ' disabled' : '';
+		$readonly  = $this->readonly;
+
+		// Start the radio field output.
+		$html[] = '<fieldset id="' . $this->id . '"' . $class . $required . $autofocus . $disabled . ' >';
+
+		// Get the field options.
+		$options = $this->getOptions();
+
+		// Build the radio field output.
+		foreach ($options as $i => $option)
+		{
+			// Initialize some option attributes.
+			$checked = ((string) $option->value == (string) $this->value) ? ' checked="checked"' : '';
+			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
+			$disabled = !empty($option->disable) || ($readonly && !$checked);
+			$disabled = $disabled ? ' disabled' : '';
+
+			// Initialize some JavaScript option attributes.
+			$onclick = !empty($option->onclick) ? ' onclick="' . $option->onclick . '"' : '';
+			$onchange = !empty($option->onchange) ? ' onchange="' . $option->onchange . '"' : '';
+
+			$html[] = '<input type="radio" id="' . $this->id . $i . '" name="' . $this->name . '" value="'
+				. htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $class . $required . $onclick
+				. $onchange . $disabled . ' />';
+
+			$html[] = '<label for="' . $this->id . $i . '"' . $class . ' >'
+				. JText::alt($option->text, preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname)) . '</label>';
+
+			$required = '';
+		}
+
+		// End the radio field output.
+		$html[] = '</fieldset>';
+
+		return implode($html);
+	}
 }


### PR DESCRIPTION
Hi Nicholas,

This PR adds the btn-group class to radio buttons of FOFFormFieldRadio so they're rendered just as the Joomla 3 core radio buttons. I tested with Joomla 3.2.2 and 2.5 and it works for both versions.

Do you foresee issues with this? I don't think people would like to render radio buttons in the classic style? Of course they could create their own FOFFormField if they really want to.

Cheers,
Jurian Even
