### PR TITLE
Update selectrow.php

### DIFF
--- a/fof/form/field/selectrow.php
+++ b/fof/form/field/selectrow.php
@@ -106,11 +106,12 @@ class FOFFormFieldSelectrow extends JFormField implements FOFFormField
 		// Is this record checked out?
 		$checked_out     = false;
 		$locked_by_field = $this->item->getColumnAlias('locked_by');
+		$myId            = JFactory::getUser()->get('id', 0);
 
 		if (property_exists($this->item, $locked_by_field))
 		{
 			$locked_by   = $this->item->$locked_by_field;
-			$checked_out = ($locked_by != 0);
+			$checked_out = ($locked_by != 0 && $locked_by != $myId);
 		}
 
 		// Get the key id for this record


### PR DESCRIPTION
As the global Joomla! checkin do not work for FOF-Tables (due to their field naming conventions), items who are locked by myself should still be selectable for me.
