### PR TITLE
~ Use same markup for toolbar title as Joomla! core

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ FOF 2.2.0
 ~ gh-278 Made $app->redirect() not use the deprecated API
 ~ AJAX ordering now shows the ordering value textbox next to the ordering handle
 ~ Minified Akeeba Strapper stylesheets
+~ Use same markup for toolbar title as Joomla! core
 # [LOW] Notice in render/strapper.php
 # [LOW] gh-246 Fix wrong singularize result for word "menus"
 # [LOW] gh-247 Grouped list field uses getOptions instead of getGroups, leading to a fatal error

--- a/fof/toolbar/toolbar.php
+++ b/fof/toolbar/toolbar.php
@@ -420,7 +420,7 @@ class FOFToolbar
 
 		// Set toolbar title
 		$subtitle_key = strtoupper($option . '_TITLE_' . $this->input->getCmd('view', 'cpanel') . '_READ');
-		JToolBarHelper::title(JText::_(strtoupper($option)) . ' &ndash; <small>' . JText::_($subtitle_key) . '</small>', $componentName);
+		JToolBarHelper::title(JText::_(strtoupper($option)) . ': ' . JText::_($subtitle_key), $componentName);
 
 		// Set toolbar icons
 		JToolBarHelper::back();
@@ -444,7 +444,7 @@ class FOFToolbar
 
 		// Set toolbar title
 		$subtitle_key = strtoupper($option . '_TITLE_' . FOFInflector::pluralize($this->input->getCmd('view', 'cpanel'))) . '_EDIT';
-		JToolBarHelper::title(JText::_(strtoupper($option)) . ' &ndash; <small>' . JText::_($subtitle_key) . '</small>', $componentName);
+		JToolBarHelper::title(JText::_(strtoupper($option)) . ': ' . JText::_($subtitle_key), $componentName);
 
 		// Set toolbar icons
         if ($this->perms->edit || $this->perms->editown)
@@ -790,7 +790,6 @@ class FOFToolbar
 		{
 			case 'title':
 				$icon = isset($attributes['icon']) ? $attributes['icon'] : 'generic.png';
-
 				JToolbarHelper::title($value, $icon);
 				break;
 


### PR DESCRIPTION
The &lt;small&gt; part is not used by Joomla core and not styled correctly, which makes the subtitles gray. I also removed the dash and used a colon, just like the Joomla! core.
