### PR TITLE
Keep posted form data

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -1341,6 +1341,13 @@ class FOFModel extends FOFUtilsObject
 
 			if ($validateResult === false)
 			{
+				if ($this->_savestate)
+				{
+					$session = JFactory::getSession();
+					$hash = $this->getHash() . 'savedata';
+					$session->set($hash, serialize($allData));
+				}
+				
 				return false;
 			}
 		}


### PR DESCRIPTION
Whenever errors are found during a save by the table object and the savestate option is set FOF stores the data in the session. However when a form has serverside validation and an error is found, the data is not stored in the ssession. This leads to loss of already filled in form data. My proposal is to also store the posted data in the session whenever a server side validation fails. To me this makes the behavior consistent.
