### PR TITLE
addded usergroup.php to /form/field/ and /form/header/ folders

### DIFF
--- a/fof/form/field/usergroup.php
+++ b/fof/form/field/usergroup.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @package    FrameworkOnFramework
+ * @subpackage form
+ * @subpackage form
+ * @copyright  Copyright (C) 2010 - 2012 Akeeba Ltd. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+// Protect from unauthorized access
+defined('_JEXEC') or die;
+
+if (!class_exists('JFormFieldUsergroup'))
+{
+	require_once JPATH_LIBRARIES . '/joomla/form/fields/usergroup.php';
+}
+
+/**
+ * Form Field class for FOF
+ * Joomla! user groups
+ *
+ * @package  FrameworkOnFramework
+ * @since    2.0
+ */
+class FOFFormFieldUsergroup extends JFormFieldUsergroup implements FOFFormField
+{
+	protected $static;
+
+	protected $repeatable;
+	
+	/** @var int A monotonically increasing number, denoting the row number in a repeatable view */
+	public $rowid;
+	
+	/** @var   FOFTable  The item being rendered in a repeatable form field */
+	public $item;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to the the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   2.0
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'static':
+				if (empty($this->static))
+				{
+					$this->static = $this->getStatic();
+				}
+
+				return $this->static;
+				break;
+
+			case 'repeatable':
+				if (empty($this->repeatable))
+				{
+					$this->repeatable = $this->getRepeatable();
+				}
+
+				return $this->static;
+				break;
+
+			default:
+				return parent::__get($name);
+		}
+	}
+
+	/**
+	 * Get the rendering of this field type for static display, e.g. in a single
+	 * item view (typically a "read" task).
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getStatic()
+	{
+		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+
+		$params = $this->getOptions();
+
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		$query->select('a.id AS value, a.title AS text');
+		$query->from('#__usergroups AS a');
+		$query->group('a.id, a.title');
+		$query->order('a.id ASC');
+		$query->order($query->qn('title') . ' ASC');
+
+		// Get the options.
+		$db->setQuery($query);
+		$options = $db->loadObjectList();
+
+		// If params is an array, push these options to the array
+		if (is_array($params))
+		{
+			$options = array_merge($params, $options);
+		}
+
+		// If all levels is allowed, push it into the array.
+		elseif ($params)
+		{
+			array_unshift($options, JHtml::_('select.option', '', JText::_('JOPTION_ACCESS_SHOW_ALL_LEVELS')));
+		}
+
+		return '<span id="' . $this->id . '" ' . $class . '>' .
+			htmlspecialchars(FOFFormFieldList::getOptionName($options, $this->value), ENT_COMPAT, 'UTF-8') .
+			'</span>';
+	}
+
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+
+		//$params = $this->getOptions();
+
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		$query->select('a.id AS value, a.title AS text');
+		$query->from('#__usergroups AS a');
+		$query->group('a.id, a.title');
+		$query->order('a.id ASC');
+		$query->order($query->qn('title') . ' ASC');
+
+		// Get the options.
+		$db->setQuery($query);
+		$options = $db->loadObjectList();
+
+		// If params is an array, push these options to the array
+/*
+		if (is_array($params))
+		{
+			$options = array_merge($params, $options);
+		}
+
+		// If all levels is allowed, push it into the array.
+		elseif ($params)
+		{
+			array_unshift($options, JHtml::_('select.option', '', JText::_('JOPTION_ACCESS_SHOW_ALL_LEVELS')));
+		}
+*/
+
+		return '<span class="' . $this->id . ' ' . $class . '">' .
+			htmlspecialchars(FOFFormFieldList::getOptionName($options, $this->value), ENT_COMPAT, 'UTF-8') .
+			'</span>';
+	}
+}

--- a/fof/form/header/usergroup.php
+++ b/fof/form/header/usergroup.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package    FrameworkOnFramework
+ * @subpackage form
+ * @copyright  Copyright (C) 2010 - 2014 Akeeba Ltd. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+// Protect from unauthorized access
+defined('FOF_INCLUDED') or die;
+
+/**
+ * User group field header
+ *
+ * @package  FrameworkOnFramework
+ * @since    2.0
+ */
+class FOFFormHeaderUsergroup extends FOFFormHeaderFieldselectable
+{
+	/**
+	 * Method to get the list of user groups
+	 *
+	 * @return  array	A list of user groups.
+	 *
+	 * @since   2.0
+	 */
+	protected function getOptions()
+	{
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		$query->select('a.id AS value, a.title AS text');
+		$query->from('#__usergroups AS a');
+		$query->group('a.id, a.title');
+		$query->order('a.id ASC');
+		$query->order($query->qn('title') . ' ASC');
+
+		// Get the options.
+		$db->setQuery($query);
+		$options = $db->loadObjectList();
+
+		return $options;
+	}
+}


### PR DESCRIPTION
Need to use Joomla's #__usergroups in my FOF XML forms.

This PR pertains to the plural XML view only, as the singular XML view works wonderfully when using:

```
<field name="usergroup"
               type="usergroup"
               label="COM_FOOBAR_VIEW_FIELD_LABEL"
               required="true"
        />
```

Although FOF does not have its own field specification for #__usergroups, Joomla does have its own. What a wonderful example of "Framework on Framework"!

The plural view needs FOF love, though. 

So, based on FOF's accesslevel form, I created this usergroup field. 

Unlike accesslevel, there is no concept of "allowed" usergroup. So, line 128 in /form/field/usergroup.php, and its if..then statements, should be deleted. As well, /form/header/usergroup.php should be deleted as well. 

Instead of deleting the code, I commented it out. 

I am imposing on you (Nicholas et al) to do this deletion because I confess to confusion with #__viewlevels  and #__usergroups.  

Thank you for taking the time to review this PR,
-Bob
