### PR TITLE
Handle empty and default calendar values

### DIFF
--- a/fof/form/field/calendar.php
+++ b/fof/form/field/calendar.php
@@ -25,10 +25,10 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 	protected $static;
 
 	protected $repeatable;
-	
+
 	/** @var   FOFTable  The item being rendered in a repeatable form field */
 	public $item;
-	
+
 	/** @var int A monotonically increasing number, denoting the row number in a repeatable view */
 	public $rowid;
 
@@ -107,14 +107,28 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 	protected function getCalendar($display)
 	{
 		// Initialize some field attributes.
-		$format = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
-		$class  = $this->element['class'] ? (string) $this->element['class'] : '';
+		$format  = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
+		$class   = $this->element['class'] ? (string) $this->element['class'] : '';
+		$default = $this->element['default'] ? (string) $this->element['default'] : '';
 
 		// PHP date doesn't use percentages (%) for the format, but the calendar Javascript
 		// DOES use it (@see: calendar-uncompressed.js). Therefore we have to convert it.
 		$formatJS  = $format;
 		$formatPHP = str_replace(array('%', 'H:M:S'), array('', 'H:i:s'), $formatJS);
-		
+
+		// Check for empty date values
+		if (empty($this->value) || $this->value == '0000-00-00 00:00:00' || $this->value == '0000-00-00')
+		{
+			if ($default == 'now')
+			{
+				$this->value = $default;
+			}
+			else
+			{
+				$this->value = 0;
+			}
+		}
+
 		// Get some system objects.
 		$config = FOFPlatform::getInstance()->getConfig();
 		$user   = JFactory::getUser();


### PR DESCRIPTION
Currently when you use the calendar field and there is no value a few things can happen. Having not set a format in the XML gives you a date like this:
-0001-11-30

Having set a format like %d-%m-%Y yields this error:
DateTime::__construct(): Failed to parse time string (30-11--0001) at position 0 (3): Unexpected character 

This change checks if the value is empty or if an empty date/datetime stamp is received. If so it either applies a default setting which can be set in the XML or if not set it falls back to 0. Going back to 0 will show a normal timestamp of 1 January first 1970 which is better than -0001-11-30 :)

Being able to use a default timestamp of now, you can have the date set to the current timestamp.
