### PR TITLE
onAfterSave should return a boolean

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -1347,7 +1347,7 @@ class FOFModel extends FOFUtilsObject
 					$hash = $this->getHash() . 'savedata';
 					$session->set($hash, serialize($allData));
 				}
-				
+
 				return false;
 			}
 		}
@@ -2721,6 +2721,8 @@ class FOFModel extends FOFUtilsObject
 
 			$name = $this->name;
 			FOFPlatform::getInstance()->runPlugins($this->event_after_save, array($this->option . '.' . $name, &$table, $this->_isNewRecord));
+
+			return true;
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
The docblock says the onAfterSave method should return a boolean, which it currently doesn't do. This PR returns true if no issues have occured.
