### PR TITLE
State should also be saved if there is a problem in the onBeforeSave

### DIFF
--- a/fof/model/model.php
+++ b/fof/model/model.php
@@ -1354,6 +1354,13 @@ class FOFModel extends FOFUtilsObject
 
 		if (!$this->onBeforeSave($allData, $table))
 		{
+			if ($this->_savestate)
+			{
+				$session = JFactory::getSession();
+				$hash = $this->getHash() . 'savedata';
+				$session->set($hash, serialize($allData));
+			}
+
 			return false;
 		}
 		else


### PR DESCRIPTION
Whenever there is an error the model saves the state if this is set to true. Currently this does not happen if there is a problem with the onBeforeSave() method. State should also be saved in this case since it is also running into a problem.
