### PR TITLE
Add Class FOFTable to tags contenttype creation

### DIFF
--- a/fof/table/behavior/tags.php
+++ b/fof/table/behavior/tags.php
@@ -141,6 +141,7 @@ class FOFTableBehaviorTags extends FOFTableBehavior
 						'key'     => $table->getKeyName(),
 						'type'    => $name,
 						'prefix'  => $options['table_prefix'],
+						'class'   => 'FOFTable',
 						'config'  => 'array()'
 					),
 					'common' => array(


### PR DESCRIPTION
Because tags runs before content history.
