### PR TITLE
[fix] calendar field

### DIFF
--- a/fof/form/field/calendar.php
+++ b/fof/form/field/calendar.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package    FrameworkOnFramework
- * @subpackage form
- * @copyright  Copyright (C) 2010 - 2014 Akeeba Ltd. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     FrameworkOnFramework
+ * @subpackage  form
+ * @copyright   Copyright (C) 2010 - 2014 Akeeba Ltd. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 // Protect from unauthorized access
 defined('FOF_INCLUDED') or die;
@@ -95,7 +95,7 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 	/**
 	 * Method to get the calendar input markup.
 	 *
-	 * @param	string	$display	The display to render ('static' or 'repeatable')
+	 * @param   string  $display  The display to render ('static' or 'repeatable')
 	 *
 	 * @return  string	The field input markup.
 	 *
@@ -116,48 +116,46 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 		// Check for empty date values
 		if (empty($this->value) || $this->value == '0000-00-00 00:00:00' || $this->value == '0000-00-00')
 		{
-			if ($default == 'now')
-			{
-				$this->value = $default;
-			}
-			else
-			{
-				$this->value = 0;
-			}
+			$this->value = $default;
 		}
 
 		// Get some system objects.
 		$config = FOFPlatform::getInstance()->getConfig();
 		$user   = JFactory::getUser();
-		$date   = FOFPlatform::getInstance()->getDate($this->value, 'UTC');
 
-		// If a known filter is given use it.
-		switch (strtoupper((string) $this->element['filter']))
+		// Format date if exists
+		if (!empty($this->value))
 		{
-			case 'SERVER_UTC':
-				// Convert a date to UTC based on the server timezone.
-				if ((int) $this->value)
-				{
-					// Get a date object based on the correct timezone.
-					$date->setTimezone(new DateTimeZone($config->get('offset')));
-				}
-				break;
+			$date   = FOFPlatform::getInstance()->getDate($this->value, 'UTC');
 
-			case 'USER_UTC':
-				// Convert a date to UTC based on the user timezone.
-				if ((int) $this->value)
-				{
-					// Get a date object based on the correct timezone.
-					$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
-				}
-				break;
+			// If a known filter is given use it.
+			switch (strtoupper((string) $this->element['filter']))
+			{
+				case 'SERVER_UTC':
+					// Convert a date to UTC based on the server timezone.
+					if ((int) $this->value)
+					{
+						// Get a date object based on the correct timezone.
+						$date->setTimezone(new DateTimeZone($config->get('offset')));
+					}
+					break;
 
-			default:
-				break;
+				case 'USER_UTC':
+					// Convert a date to UTC based on the user timezone.
+					if ((int) $this->value)
+					{
+						// Get a date object based on the correct timezone.
+						$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+					}
+					break;
+
+				default:
+					break;
+			}
+
+			// Transform the date string.
+			$this->value = $date->format($formatPHP, true, false);
 		}
-
-		// Transform the date string.
-		$this->value = $date->format($formatPHP, true, false);
 
 		if ($display == 'static')
 		{
@@ -168,26 +166,32 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 			{
 				$attributes['size'] = (int) $this->element['size'];
 			}
+
 			if ($this->element['maxlength'])
 			{
 				$attributes['maxlength'] = (int) $this->element['maxlength'];
 			}
+
 			if ($this->element['class'])
 			{
 				$attributes['class'] = (string) $this->element['class'];
 			}
+
 			if ((string) $this->element['readonly'] == 'true')
 			{
 				$attributes['readonly'] = 'readonly';
 			}
+
 			if ((string) $this->element['disabled'] == 'true')
 			{
 				$attributes['disabled'] = 'disabled';
 			}
+
 			if ($this->element['onchange'])
 			{
 				$attributes['onchange'] = (string) $this->element['onchange'];
 			}
+
 			if ($this->required)
 			{
 				$attributes['required'] = 'required';


### PR DESCRIPTION
I think a strange behavior was introduced in https://github.com/akeeba/fof/pull/289

After that PR the default value is forced to 'now' or 0 which I think is wrong. In my opinion we should allow the field to be shown empty. Neither `1970-01-01` or `-0001-11-30` are a good value to show. 

This PR allows you to use the default value you want. For example if you really like to see a 1970 date:

``` xml
        <field name="due" type="calendar"
            class="inputbox"
            label="COM_TODO_ITEMS_FIELD_DUE"
            labelclass="todo-label"
            required="true"
            size="20"
            default="1970-01-01"
         />
```

The value 'now' still works as expected because anything passed will be directly passed to the date object.

Summary:
- Empty default value = no date shown 
- `now` = current date
- Any other default value = JDate is initialised with that value
