### PR TITLE
Move checking of alias to table function

### DIFF
--- a/fof/table/behavior/contenthistory.php
+++ b/fof/table/behavior/contenthistory.php
@@ -26,7 +26,7 @@ class F0FTableBehaviorContenthistory extends F0FTableBehavior
 	public function onAfterStore(&$table)
 	{
 		$aliasParts = explode('.', $table->getContentType());
-		$this->checkContentType($table);
+		$table->checkContentType();
 
 		if (JComponentHelper::getParams($aliasParts[0])->get('save_history', 0))
 		{
@@ -56,127 +56,5 @@ class F0FTableBehaviorContenthistory extends F0FTableBehavior
 		}
 
 		return true;
-	}
-
-	/**
-	 * Check if a UCM content type exists for this resource, and
-	 * create it if it does not
-	 *
-	 * @param   F0FTable   &$table  	The table which calls this event
-	 *
-	 */
-	protected function checkContentType(&$table)
-	{
-		$contentType = new JTableContenttype($table->getDbo());
-
-		$alias = $table->getContentType();
-
-		$aliasParts = explode('.', $table->getContentType());
-		$input = new F0FInput;
-		$options = array(
-			'component' 	=> $aliasParts[0],
-			'view'		=> $aliasParts[1],
-			'table_prefix'	=> ucfirst(F0FInflector::pluralize(substr($aliasParts[0], strpos($aliasParts[0], "_")  + 1)) . 'Table')
-		);
-
-		// Fetch the extension name
-		$component = $options['component'];
-		$component = JComponentHelper::getComponent($component);
-
-		// Fetch the name using the menu item
-		$query = $table->getDbo()->getQuery(true);
-		$query->select('title')->from('#__menu')->where('component_id = ' . (int) $component->id);
-		$table->getDbo()->setQuery($query);
-		$component_name = JText::_($table->getDbo()->loadResult());
-
-		$name = $component_name . ' ' . ucfirst($options['view']);
-
-		// Create a new content type for our resource
-		if (!$contentType->load(array('type_alias' => $alias)))
-		{
-			$contentType->type_title = $name;
-			$contentType->type_alias = $alias;
-			$contentType->table = json_encode(
-				array(
-					'special' => array(
-						'dbtable' => $table->getTableName(),
-						'key'     => $table->getKeyName(),
-						'type'    => $name,
-						'prefix'  => $options['table_prefix'],
-						'class'   => 'F0FTable',
-						'config'  => 'array()'
-					),
-					'common' => array(
-						'dbtable' => '#__ucm_content',
-						'key' => 'ucm_id',
-						'type' => 'CoreContent',
-						'prefix' => 'JTable',
-						'config' => 'array()'
-					)
-				)
-			);
-
-			$contentType->field_mappings = json_encode(
-				array(
-					'common' => array(
-						0 => array(
-							"core_content_item_id" => $table->getKeyName(),
-							"core_title"           => $this->getUcmCoreAlias($table, 'title'),
-							"core_state"           => $this->getUcmCoreAlias($table, 'enabled'),
-							"core_alias"           => $this->getUcmCoreAlias($table, 'alias'),
-							"core_created_time"    => $this->getUcmCoreAlias($table, 'created_on'),
-							"core_modified_time"   => $this->getUcmCoreAlias($table, 'created_by'),
-							"core_body"            => $this->getUcmCoreAlias($table, 'body'),
-							"core_hits"            => $this->getUcmCoreAlias($table, 'hits'),
-							"core_publish_up"      => $this->getUcmCoreAlias($table, 'publish_up'),
-							"core_publish_down"    => $this->getUcmCoreAlias($table, 'publish_down'),
-							"core_access"          => $this->getUcmCoreAlias($table, 'access'),
-							"core_params"          => $this->getUcmCoreAlias($table, 'params'),
-							"core_featured"        => $this->getUcmCoreAlias($table, 'featured'),
-							"core_metadata"        => $this->getUcmCoreAlias($table, 'metadata'),
-							"core_language"        => $this->getUcmCoreAlias($table, 'language'),
-							"core_images"          => $this->getUcmCoreAlias($table, 'images'),
-							"core_urls"            => $this->getUcmCoreAlias($table, 'urls'),
-							"core_version"         => $this->getUcmCoreAlias($table, 'version'),
-							"core_ordering"        => $this->getUcmCoreAlias($table, 'ordering'),
-							"core_metakey"         => $this->getUcmCoreAlias($table, 'metakey'),
-							"core_metadesc"        => $this->getUcmCoreAlias($table, 'metadesc'),
-							"core_catid"           => $this->getUcmCoreAlias($table, 'cat_id'),
-							"core_xreference"      => $this->getUcmCoreAlias($table, 'xreference'),
-							"asset_id"             => $this->getUcmCoreAlias($table, 'asset_id')
-						)
-					),
-					'special' => array(
-						0 => array(
-						)
-					)
-				)
-			);
-
-			$contentType->router = '';
-
-			$contentType->store();
-		}
-	}
-
-	/**
-	 * Utility methods that fetches the column name for the field.
-	 * If it does not exists, returns a "null" string
-	 *
-	 * @param   F0FTable   $table  	The table which calls this event
-	 * @param   string     $alias   The alias of the content type
-	 *
-	 * @return string The column name
-	 */
-	protected function getUcmCoreAlias($table, $alias)
-	{
-		$alias = $table->getColumnAlias($alias);
-
-		if (in_array($alias, $table->getKnownFields()))
-		{
-			return $alias;
-		}
-
-		return "null";
 	}
 }

--- a/fof/table/behavior/tags.php
+++ b/fof/table/behavior/tags.php
@@ -36,7 +36,7 @@ class F0FTableBehaviorTags extends F0FTableBehavior
 			}
 
 			// Check if the content type exists, and create it if it does not
-			$this->checkContentType($table, $options);
+			$table->checkContentType();
 
 			$tagsTable = clone($table);
 
@@ -104,114 +104,5 @@ class F0FTableBehaviorTags extends F0FTableBehavior
 				return false;
 			}
 		}
-	}
-
-	/**
-	 * Check if a UCM content type exists for this resource, and
-	 * create it if it does not
-	 */
-	protected function checkContentType(&$table, $options)
-	{
-		$contentType = new JTableContenttype($table->getDbo());
-
-		$alias = $table->getContentType();
-		$aliasParts = explode('.', $alias);
-
-		// Fetch the extension name
-		$component = $aliasParts[0];
-		$component = JComponentHelper::getComponent($component);
-
-		// Fetch the name using the menu item
-		$query = $table->getDbo()->getQuery(true);
-		$query->select('title')->from('#__menu')->where('component_id = ' . (int) $component->id);
-		$table->getDbo()->setQuery($query);
-		$component_name = JText::_($table->getDbo()->loadResult());
-
-		$name = $component_name . ' ' . ucfirst($aliasParts[1]);
-
-		// Create a new content type for our resource
-		if (!$contentType->load(array('type_alias' => $alias)))
-		{
-			$contentType->type_title = $name;
-			$contentType->type_alias = $alias;
-			$contentType->table = json_encode(
-				array(
-					'special' => array(
-						'dbtable' => $table->getTableName(),
-						'key'     => $table->getKeyName(),
-						'type'    => $name,
-						'prefix'  => $options['table_prefix'],
-						'class'   => 'F0FTable',
-						'config'  => 'array()'
-					),
-					'common' => array(
-						'dbtable' => '#__ucm_content',
-						'key' => 'ucm_id',
-						'type' => 'CoreContent',
-						'prefix' => 'JTable',
-						'config' => 'array()'
-					)
-				)
-			);
-
-			$contentType->field_mappings = json_encode(
-				array(
-					'common' => array(
-						0 => array(
-							"core_content_item_id" => $table->getKeyName(),
-							"core_title"           => $this->getUcmCoreAlias($table, 'title'),
-							"core_state"           => $this->getUcmCoreAlias($table, 'enabled'),
-							"core_alias"           => $this->getUcmCoreAlias($table, 'alias'),
-							"core_created_time"    => $this->getUcmCoreAlias($table, 'created_on'),
-							"core_modified_time"   => $this->getUcmCoreAlias($table, 'created_by'),
-							"core_body"            => $this->getUcmCoreAlias($table, 'body'),
-							"core_hits"            => $this->getUcmCoreAlias($table, 'hits'),
-							"core_publish_up"      => $this->getUcmCoreAlias($table, 'publish_up'),
-							"core_publish_down"    => $this->getUcmCoreAlias($table, 'publish_down'),
-							"core_access"          => $this->getUcmCoreAlias($table, 'access'),
-							"core_params"          => $this->getUcmCoreAlias($table, 'params'),
-							"core_featured"        => $this->getUcmCoreAlias($table, 'featured'),
-							"core_metadata"        => $this->getUcmCoreAlias($table, 'metadata'),
-							"core_language"        => $this->getUcmCoreAlias($table, 'language'),
-							"core_images"          => $this->getUcmCoreAlias($table, 'images'),
-							"core_urls"            => $this->getUcmCoreAlias($table, 'urls'),
-							"core_version"         => $this->getUcmCoreAlias($table, 'version'),
-							"core_ordering"        => $this->getUcmCoreAlias($table, 'ordering'),
-							"core_metakey"         => $this->getUcmCoreAlias($table, 'metakey'),
-							"core_metadesc"        => $this->getUcmCoreAlias($table, 'metadesc'),
-							"core_catid"           => $this->getUcmCoreAlias($table, 'cat_id'),
-							"core_xreference"      => $this->getUcmCoreAlias($table, 'xreference'),
-							"asset_id"             => $this->getUcmCoreAlias($table, 'asset_id')
-						)
-					),
-					'special' => array(
-						0 => array(
-						)
-					)
-				)
-			);
-
-			$contentType->router = '';
-
-			$contentType->store();
-		}
-	}
-
-	/**
-	 * Utility methods that fetches the column name for the field.
-	 * If it does not exists, returns a "null" string
-	 *
-	 * @return string The column name
-	 */
-	protected function getUcmCoreAlias($table, $alias)
-	{
-		$alias = $table->getColumnAlias($alias);
-
-		if (in_array($alias, $table->getKnownFields()))
-		{
-			return $alias;
-		}
-
-		return "null";
 	}
 }

--- a/fof/table/table.php
+++ b/fof/table/table.php
@@ -3665,4 +3665,139 @@ class F0FTable extends F0FUtilsObject implements JTableInterface
 	{
 		return $this->_configProviderKey;
 	}
+
+	/**
+	 * Check if a UCM content type exists for this resource, and
+	 * create it if it does not
+	 *
+	 * @param  string  $alias  The content type alias (optional)
+	 *
+	 * @return  null
+	 */
+	public function checkContentType($alias)
+	{
+		$contentType = new JTableContenttype($this->getDbo());
+
+		if (!$alias)
+		{
+			$alias = $this->getContentType();
+		}
+
+		$aliasParts = explode('.', $alias);
+
+		// Fetch the extension name
+		$component = $aliasParts[0];
+		$component = JComponentHelper::getComponent($component);
+
+		// Fetch the name using the menu item
+		$query = $this->getDbo()->getQuery(true);
+		$query->select('title')->from('#__menu')->where('component_id = ' . (int) $component->id);
+		$this->getDbo()->setQuery($query);
+		$component_name = JText::_($this->getDbo()->loadResult());
+
+		$name = $component_name . ' ' . ucfirst($aliasParts[1]);
+
+		// Create a new content type for our resource
+		if (!$contentType->load(array('type_alias' => $alias)))
+		{
+			$contentType->type_title = $name;
+			$contentType->type_alias = $alias;
+			$contentType->table = json_encode(
+				array(
+					'special' => array(
+						'dbtable' => $table->getTableName(),
+						'key'     => $table->getKeyName(),
+						'type'    => $name,
+						'prefix'  => $this->_tablePrefix,
+						'class'   => 'F0FTable',
+						'config'  => 'array()'
+					),
+					'common' => array(
+						'dbtable' => '#__ucm_content',
+						'key' => 'ucm_id',
+						'type' => 'CoreContent',
+						'prefix' => 'JTable',
+						'config' => 'array()'
+					)
+				)
+			);
+
+			$contentType->field_mappings = json_encode(
+				array(
+					'common' => array(
+						0 => array(
+							"core_content_item_id" => $table->getKeyName(),
+							"core_title"           => $this->getUcmCoreAlias('title'),
+							"core_state"           => $this->getUcmCoreAlias('enabled'),
+							"core_alias"           => $this->getUcmCoreAlias('alias'),
+							"core_created_time"    => $this->getUcmCoreAlias('created_on'),
+							"core_modified_time"   => $this->getUcmCoreAlias('created_by'),
+							"core_body"            => $this->getUcmCoreAlias('body'),
+							"core_hits"            => $this->getUcmCoreAlias('hits'),
+							"core_publish_up"      => $this->getUcmCoreAlias('publish_up'),
+							"core_publish_down"    => $this->getUcmCoreAlias('publish_down'),
+							"core_access"          => $this->getUcmCoreAlias('access'),
+							"core_params"          => $this->getUcmCoreAlias('params'),
+							"core_featured"        => $this->getUcmCoreAlias('featured'),
+							"core_metadata"        => $this->getUcmCoreAlias('metadata'),
+							"core_language"        => $this->getUcmCoreAlias('language'),
+							"core_images"          => $this->getUcmCoreAlias('images'),
+							"core_urls"            => $this->getUcmCoreAlias('urls'),
+							"core_version"         => $this->getUcmCoreAlias('version'),
+							"core_ordering"        => $this->getUcmCoreAlias('ordering'),
+							"core_metakey"         => $this->getUcmCoreAlias('metakey'),
+							"core_metadesc"        => $this->getUcmCoreAlias('metadesc'),
+							"core_catid"           => $this->getUcmCoreAlias('cat_id'),
+							"core_xreference"      => $this->getUcmCoreAlias('xreference'),
+							"asset_id"             => $this->getUcmCoreAlias('asset_id')
+						)
+					),
+					'special' => array(
+						0 => array(
+						)
+					)
+				)
+			);
+
+			$ignoreFields = array(
+				$this->getUcmCoreAlias('modified_on', null),
+				$this->getUcmCoreAlias('modified_by', null),
+				$this->getUcmCoreAlias('locked_by', null),
+				$this->getUcmCoreAlias('locked_on', null),
+				$this->getUcmCoreAlias('hits', null),
+				$this->getUcmCoreAlias('version', null)
+			);
+
+			$contentType->content_history_options = json_encode(
+				array(
+					"ignoreChanges" => array_filter($ignoreFields, 'strlen')
+				)
+			);
+
+			$contentType->router = '';
+
+			$contentType->store();
+		}
+	}
+
+	/**
+	 * Utility methods that fetches the column name for the field.
+	 * If it does not exists, returns a "null" string
+	 *
+	 * @param  string  $alias  The alias for the column
+	 * @param  string  $null   What to return if no column exists
+	 *
+	 * @return string The column name
+	 */
+	protected function getUcmCoreAlias($alias, $null = "null")
+	{
+		$alias = $this->getColumnAlias($alias);
+
+		if (in_array($alias, $this->getKnownFields()))
+		{
+			return $alias;
+		}
+
+		return $null;
+	}
 }


### PR DESCRIPTION
This function is duplicated in both content history and tags and it makes more sense to move it to a common class (i.e. JTable). I've also added in a bit more content history stuff to ignore changes to certain fields.

My localhost on my laptop appears to be fooked (pressing start doesn't start :( ) so haven't been able to test this yet. So you might want to hold merging this until I fix it or can set up something on my own hosting (unless you have an undying urge to test it yourself :P)
