### PR TITLE
Don't render headings for tabbed fieldsets

### DIFF
--- a/fof/render/strapper.php
+++ b/fof/render/strapper.php
@@ -1139,7 +1139,9 @@ HTML;
 
 		$html .= "\t" . '<div id="' . $fieldset->name . '" ' . $class . '>' . PHP_EOL;
 
-		if (isset($fieldset->label) && !empty($fieldset->label))
+		$isTabbedFieldset = $this->isTabFieldset($fieldset);
+
+		if (isset($fieldset->label) && !empty($fieldset->label) && !$isTabbedFieldset)
 		{
 			$html .= "\t\t" . '<h3>' . JText::_($fieldset->label) . '</h3>' . PHP_EOL;
 		}


### PR DESCRIPTION
(the tab itself already shows the tab title)
