### PR TITLE
Wrap backend output in various classes and add #akeeba-strapper.

### DIFF
--- a/fof/render/joomla.php
+++ b/fof/render/joomla.php
@@ -55,7 +55,7 @@ class F0FRenderJoomla extends F0FRenderAbstract
 			return;
 		}
 
-		// Wrap output in a Joomla-versioned div
+		// Wrap output in various classes
 		$version = new JVersion;
 		$versionParts = explode('.', $version->RELEASE);
 		$minorVersion = str_replace('.', '', $version->RELEASE);
@@ -90,7 +90,7 @@ class F0FRenderJoomla extends F0FRenderAbstract
 			);
 		}
 
-		echo '<div id="akeeba-bootstrap" class="' . implode($classes, ' ') . "\">\n";
+		echo '<div id="akeeba-renderjoomla" class="' . implode($classes, ' ') . "\">\n";
 
 		// Render submenu and toolbar (only if asked to)
 		if ($input->getBool('render_toolbar', true))
@@ -130,7 +130,7 @@ class F0FRenderJoomla extends F0FRenderAbstract
 			return;
 		}
 
-		echo "</div>\n";
+		echo "</div>\n";    // Closes akeeba-renderjoomla div
 	}
 
 	/**

--- a/fof/render/joomla3.php
+++ b/fof/render/joomla3.php
@@ -48,6 +48,42 @@ class F0FRenderJoomla3 extends F0FRenderStrapper
 			return;
 		}
 
+		$platform = F0FPlatform::getInstance();
+
+		if ($platform->isCli())
+		{
+			return;
+		}
+
+		if ($platform->isBackend())
+		{
+			// Wrap output in various classes
+			$version = new JVersion;
+			$versionParts = explode('.', $version->RELEASE);
+			$minorVersion = str_replace('.', '', $version->RELEASE);
+			$majorVersion = array_shift($versionParts);
+
+			$area = $platform->isBackend() ? 'admin' : 'site';
+			$option = $input->getCmd('option', '');
+			$view = $input->getCmd('view', '');
+			$layout = $input->getCmd('layout', '');
+			$task = $input->getCmd('task', '');
+			$itemid = $input->getCmd('Itemid', '');
+
+			$classes = array(
+				'joomla-version-' . $majorVersion,
+				'joomla-version-' . $minorVersion,
+				$area,
+				$option,
+				'view-' . $view,
+				'layout-' . $layout,
+				'task-' . $task,
+				'itemid-' . $itemid,
+			);
+		}
+
+		echo '<div id="akeeba-renderjoomla" class="' . implode($classes, ' ') . "\">\n";
+
 		// Render the submenu and toolbar
 		if ($input->getBool('render_toolbar', true))
 		{
@@ -68,13 +104,25 @@ class F0FRenderJoomla3 extends F0FRenderStrapper
 	 */
 	public function postRender($view, $task, $input, $config = array())
 	{
-		/*
-		We don't need to do anything here, if we are running Joomla3,
-		so overwrite the default with all the closing div's
+		$format	 = $input->getCmd('format', 'html');
 
-		I added it here because I am not 100% sure if it would break BC
-		when doing it in the default strapper
-		*/
+		if (empty($format))
+		{
+			$format	 = 'html';
+		}
+
+		if ($format != 'html')
+		{
+			return;
+		}
+
+		// Closing tag only if we're not in CLI
+		if (F0FPlatform::getInstance()->isCli())
+		{
+			return;
+		}
+
+		echo "</div>\n";    // Closes akeeba-renderjoomla div
 	}
 
 	/**

--- a/fof/render/strapper.php
+++ b/fof/render/strapper.php
@@ -90,9 +90,8 @@ class F0FRenderStrapper extends F0FRenderAbstract
 			);
 		}
 
+		// Wrap output in divs
 		echo '<div id="akeeba-bootstrap" class="' . implode($classes, ' ') . "\">\n";
-
-		// Wrap output in an akeeba-bootstrap class div
 		echo "<div class=\"akeeba-bootstrap\">\n";
 		echo "<div class=\"row-fluid\">\n";
 


### PR DESCRIPTION
Also refactored preRender(): return immediately when $platform->isCli()

Github had issues with the diff and PR so I created a new one. This is updated version of PR
https://github.com/akeeba/fof/pull/339

> I'm thinking that this is security nightmare as it puts in indexable HTML the component name, view, layout, Joomla! version etc. Maybe drop our pants, lubricate our anus and bend over too? I'd say that we need to replace if (!$platform->isCli()) with if (!$platform->isAdmin()) and add an elseif (!$platform->isCli() block which outputs only the Akeeba Strapper ID and the Joomla! version class, with the prospect of removing the J! version classes from it in FOF 3.

Mzz you've got a good point regarding security... I've altered it and only output the new classes in the backend. I think this is ok?
