### PR TITLE
# [MEDIUM] Akeeba Strapper: bootstrap.min.js was loaded when it has alre...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,8 @@ FOF 2.3.1
 ~ Refactored F0F renderers
 ~ Only show ordering input fields and save button when rows are ordered by ordering (Joomla! 3)
 ~ gh-356 Akeeba Strapper: Make sure jQuery and jQuery UI are only loaded once
-# [MEDIUM] Akeeba Strapper: bootstrap.min.js was loaded when it has already been included (Joomla! 3 and Joomla! 2.5 when preload_joomla2=0)
+~ gh-358 Akeeba Strapper: Make sure Bootstrap is only loaded once
+# [MEDIUM] gh-358 Akeeba Strapper: bootstrap.min.js was loaded when it has already been included (Joomla! 3 and Joomla! 2.5 when preload_joomla2=0)
 
 FOF 2.3.0
 ================================================================================

--- a/strapper/akeeba_strapper/strapper.php
+++ b/strapper/akeeba_strapper/strapper.php
@@ -255,6 +255,12 @@ class AkeebaStrapper
             return;
 		}
 
+		// Load Bootstrap only once
+		if (self::$_includedBootstrap)
+		{
+			return;
+		}
+
 		if (version_compare(JVERSION, '3.2', 'ge'))
 		{
 			$key = 'joomla32';


### PR DESCRIPTION
...ady been included (Joomla! 3 and Joomla! 2.5 when preload_joomla2=0)

Akeeba Bootstrap loaded `bootstrap.min.js`, even when it was already included by Joomla. This happens under Joomla 3 and under Joomla 2.5 when preload_joomla2=0 (the latter not tested, but it happens at least with Joomla 3.3). This gives JavaScript issues, e.g. dropdown menu which doesn't work properly. There is already a piece of code in strapper.php which checks for this (`// Special case: check that nobody else is using bootstrap[.min].js on the page.`). This is however only executed when it’s preloaded. 

This PR always executes that check. In order to get the `$buffer` which is required for that check, I had to run the code always in the `onAfterRender` event. To accomplish this I created `AkeebaStrapperOnAfterRender()`. 

I’ve modified $jsRegex so it excludes the JavaScript tag (e.g. ?2c4cac3e6da953cad459904503f366cc). This was required to reliable check the Bootstrap Javascripts.

I've chosen to keep the Bootstrap Javascript from Akeeba Strapper in stead of Joomla, because this is the most easiest to do code wise. Also if we have some improvements sooner or later, they will be used.

TODO (other PRs):
1. The Bootstrap Javascript of Akeeba Strapper has an issue with hovering dropdown menu. It needs to be fixed or replaced by the stock Joomla core bootstrap.min.js, then it works. I'll do that, after discussing it, in another PR.
2. Just like we did for $_includedJQuery and $_includedJQueryUI, we also have to add that if check of `$_includedBootstrap` to `bootstrap()`. I confirmed this issue under Joomla 2.5 when you call `AkeebaStrapper::bootstrap();` multiple times. I can create a PR once this has been accepted.

-edit
I see the backend is now white because of the missing bootstrap.min.js. We might need to alter the script to only keep the Joomla bootstrap.min.js if it's available, else only keep the Akeeba Strapper bootstrap.min.js.
