### PR TITLE
Small documentation update

### DIFF
--- a/documentation/fof-guide.xml
+++ b/documentation/fof-guide.xml
@@ -1864,6 +1864,15 @@ public function onAfterGetItem(&amp;$model, &amp;$record)
         </varlistentry>
 
         <varlistentry>
+          <term>language</term>
+
+          <listitem>
+            <para>The language of the record if you want a multi-lingual
+            site.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>asset_id</term>
 
           <listitem>


### PR DESCRIPTION
Hi Nicholas,

I noticed that the `language` field (used in the `language` behavior) isn't refered in Magic Fields. It would be good to have it, I guess. :)
