### PR TITLE
Changed getInput() render on ordering field

### DIFF
--- a/documentation/fof-guide.xml
+++ b/documentation/fof-guide.xml
@@ -8174,6 +8174,36 @@ echo $viewTemplate;
             We recommend placing this field first on your form, to respect
             Joomla! 3.0 and later's JUI (Joomla! User Interface)
             guidelines.</para>
+
+            <para>You can set the following attributes:</para>
+
+            <itemizedlist>
+              <listitem>
+                <para><emphasis role="strong">class</emphasis> CSS
+                class</para>
+              </listitem>
+
+              <listitem>
+                <para><emphasis role="strong">readonly</emphasis> Is this a
+                read-only field?</para>
+              </listitem>
+
+              <listitem>
+                <para><emphasis role="strong">disabled</emphasis> Is this a
+                disabled form element?</para>
+              </listitem>
+
+              <listitem>
+                <para><emphasis role="strong">onchange</emphasis> The onChange
+                Javascript event</para>
+              </listitem>
+
+              <listitem>
+                <para><emphasis role="strong">ordertitle</emphasis> The field name
+                used to display the options title (if not set it will use the magic
+                <literal>title</literal> field)</para>
+              </listitem>
+            </itemizedlist>
           </section>
 
           <section xml:id="password">


### PR DESCRIPTION
I changed the `getInput()` to allow this field to be used on `edit` form render. It's based on J! 3 ordering, I adapted the `getQuery()` to make it work.

I used a new `ordertitle` attribute (I had no idea how to call it, if you have a better idea~) to manage the list options title. If not set it will check for the magic `title` field (and if not set you will got a cute SQL error).

Tested on 2.5 and 3.3 last versions.
