### PR TITLE
Added range and modulo filters, fixed filter bugs (outside, dates)

### DIFF
--- a/documentation/fof-guide.xml
+++ b/documentation/fof-guide.xml
@@ -1002,13 +1002,73 @@ function postflight($type, $parent)
                 <term>interval</term>
 
                 <listitem>
-                  <para>Returns records whose field value is following an
-                  interval (arithmetical progression)</para>
+                  <para>Returns records whose field value is inside the space
+                  between two numbers, inclusive, based on value and interval.
+                  You have the following keys:</para>
 
                   <itemizedlist>
                     <listitem>
                       <para><option>method</option> :
                       <parameter>interval</parameter></para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>value</option> : The starting value of the
+                      number space</para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>interval</option> : The interval
+                      of the number space</para>
+                    </listitem>
+                  </itemizedlist>
+
+                  <para>For example value=5 interval=2 will search for any value
+                  between 3 to 7, including 3 and 7.</para>
+                </listitem>
+              </varlistentry>
+
+              <varlistentry>
+                <term>range</term>
+
+                <listitem>
+                  <para>Returns records whose field value is inside the space
+                  in a range, inclusive. You have the following keys:</para>
+
+                  <itemizedlist>
+                    <listitem>
+                      <para><option>method</option> :
+                      <parameter>range</parameter></para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>from</option> : Left barrier of the number
+                      space</para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>to</option> : Right barrier of the number
+                      space</para>
+                    </listitem>
+                  </itemizedlist>
+
+                  <para>For example from=1 will search for any value
+                  greater than 1, including 1. And from=1 and to=10 will search
+                  for any value between 1 to 10, including 1 and 10.</para>
+                </listitem>
+              </varlistentry>
+
+              <varlistentry>
+                <term>modulo</term>
+
+                <listitem>
+                  <para>Returns records whose field value is following an
+                  modulo interval (arithmetical progression)</para>
+
+                  <itemizedlist>
+                    <listitem>
+                      <para><option>method</option> :
+                      <parameter>modulo</parameter></para>
                     </listitem>
 
                     <listitem>
@@ -1022,8 +1082,8 @@ function postflight($type, $parent)
                     </listitem>
                   </itemizedlist>
 
-                  <para>For example value=5 interval=2 will search for values
-                  5, 7, 9, 11 and so on.</para>
+                  <para>For example value=7 interval=3 will search for values
+                  7, 10, 13, 16 and so on.</para>
                 </listitem>
               </varlistentry>
             </variablelist>
@@ -1256,6 +1316,33 @@ function postflight($type, $parent)
                   </itemizedlist>
                 </listitem>
               </varlistentry>
+
+              <varlistentry>
+                <term>range</term>
+
+                <listitem>
+                  <para>Returns records whose field value is inside the space
+                  in a date range, inclusive. You have the following
+                  keys:</para>
+
+                  <itemizedlist>
+                    <listitem>
+                      <para><option>method</option> :
+                      <parameter>range</parameter></para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>from</option> : Left barrier of the date
+                      space</para>
+                    </listitem>
+
+                    <listitem>
+                      <para><option>to</option> : Right barrier of the date
+                      space</para>
+                    </listitem>
+                  </itemizedlist>
+                </listitem>
+              </varlistentry>
             </variablelist>
           </section>
 
@@ -1364,7 +1451,7 @@ function postflight($type, $parent)
           important how you name it, because FOF will search for your
           behaviors based on their name.</para>
 
-          <para>If you want to add a <code>bar</code> behavior in a 
+          <para>If you want to add a <code>bar</code> behavior in a
           <code>foo</code> component, FOF will search for it in the following order:
           </para>
 
@@ -1950,7 +2037,7 @@ public function onAfterGetItem(&amp;$model, &amp;$record)
       <programlisting language="php">function __construct($table, $key, $db, $config)
 {
     $this-&gt;setColumnAlias('enabled', 'published');
-        
+
     parent::__construct($table, $key, $db, $config);
 }</programlisting>
 
@@ -2341,7 +2428,7 @@ class FoobarTableFoo extends F0FTable
               <listitem>
                 <para>This behavior manages the content history related to the
                 current resource</para>
-                
+
                 <important>
                   <para>This behavior requires a parameter <code>save_history</code>
                   on your component parameters <filename>config.xml</filename>.</para>
@@ -2543,7 +2630,7 @@ public function onBeforeStore(&amp;$table, $updateNulls)
  * The event which runs after storing (saving) data to the database
  *
  * @param   F0FTable  &amp;$table  The table which calls this event
- * 
+ *
  * @return  boolean  True to allow saving without an error
  */
 public function onAfterStore(&amp;$table)
@@ -2559,7 +2646,7 @@ public function onAfterStore(&amp;$table)
  *
  * @return  boolean  True to allow moving
  */
-public function onBeforeMove(&amp;$table, $updateNulls) 
+public function onBeforeMove(&amp;$table, $updateNulls)
 {
     return true;
 }
@@ -2568,7 +2655,7 @@ public function onBeforeMove(&amp;$table, $updateNulls)
  * The event which runs after moving a record
  *
  * @param   F0FTable  &amp;$table  The table which calls this event
- * 
+ *
  * @return  boolean  True to allow moving without an error
  */
 public function onAfterMove(&amp;$table)
@@ -2593,7 +2680,7 @@ public function onBeforeReorder(&amp;$table, $where = '')
  * The event which runs after reordering a table
  *
  * @param   F0FTable  &amp;$table  The table which calls this event
- * 
+ *
  * @return  boolean  True to allow the reordering to complete without an error
  */
 public function onAfterReorder(&amp;$table)
@@ -2698,7 +2785,7 @@ public function onBeforePublish(&amp;$table, &amp;$cid, $publish)
  * The event which runs after the object is reset to its default values.
  *
  * @param   F0FTable &amp;$table  The table which calls this event
- * 
+ *
  * @return  boolean  True to allow the reset to complete without errors
  */
 public function onAfterReset(&amp;$table)
@@ -2710,7 +2797,7 @@ public function onAfterReset(&amp;$table)
  * The even which runs before the object is reset to its default values.
  *
  * @param   F0FTable &amp;$table  The table which calls this event
- * 
+ *
  * @return  boolean  True to allow the reset to complete
  */
 public function onBeforeReset(&amp;$table)
@@ -5393,7 +5480,7 @@ INSERT IGNORE INTO `#__admintools_profiles`
         &lt;table name="item"&gt;
             &lt;field name="enabled"&gt;published&lt;/field&gt;
         &lt;/table&gt;
-    &lt;/common&gt;    
+    &lt;/common&gt;
 
     &lt;!-- Component back-end options --&gt;
     &lt;backend&gt;
@@ -6844,7 +6931,7 @@ class="tab-pane active another-class"
 
             <programlisting language="php">&lt;?php
 $viewTemplate = $this-&gt;getRenderedForm();
-echo $viewTemplate; 
+echo $viewTemplate;
 ?&gt;</programlisting>
           </section>
         </section>

--- a/fof/model/behavior/filters.php
+++ b/fof/model/behavior/filters.php
@@ -71,10 +71,12 @@ class F0FModelBehaviorFilters extends F0FModelBehavior
 			{
 				case 'between':
 				case 'outside':
+				case 'range' :
 					$sql = $field->$method($options->get('from', null), $options->get('to'));
 					break;
 
 				case 'interval':
+				case 'modulo':
 					$sql = $field->$method($options->get('value', null), $options->get('interval'));
 					break;
 

--- a/fof/model/field.php
+++ b/fof/model/field.php
@@ -198,6 +198,33 @@ abstract class F0FModelField
 	abstract public function interval($from, $interval);
 
 	/**
+	 * Perform a between limits match (usually: search for a value between
+	 * two numbers or a date between two preset dates). When $include is true
+	 * the condition tested is:
+	 * $from <= VALUE <= $to
+	 * When $include is false the condition tested is:
+	 * $from < VALUE < $to
+	 *
+	 * @param   mixed    $from     The lowest value to compare to
+	 * @param   mixed    $to       The higherst value to compare to
+	 * @param   boolean  $include  Should we include the boundaries in the search?
+	 *
+	 * @return  string  The SQL where clause for this search
+	 */
+	abstract public function range($from, $to, $include = true);
+
+	/**
+	 * Perform an modulo search
+	 *
+	 * @param   integer|float  $value     The starting value of the search space
+	 * @param   integer|float  $interval  The interval period of the search space
+	 * @param   boolean        $include   Should I include the boundaries in the search?
+	 *
+	 * @return  string  The SQL where clause
+	 */
+	abstract public function modulo($from, $interval, $include = true);
+
+	/**
 	 * Return the SQL where clause for a search
 	 *
 	 * @param   mixed   $value     The value to search for

--- a/fof/model/field/date.php
+++ b/fof/model/field/date.php
@@ -53,8 +53,8 @@ class F0FModelFieldDate extends F0FModelFieldText
 			$extra = '=';
 		}
 
-		$sql = '((' . $this->getFieldName() . ' >' . $extra . ' ' . $from . ') AND ';
-		$sql .= '(' . $this->getFieldName() . ' <' . $extra . ' ' . $to . '))';
+		$sql = '((' . $this->getFieldName() . ' >' . $extra . ' "' . $from . '") AND ';
+		$sql .= '(' . $this->getFieldName() . ' <' . $extra . ' "' . $to . '"))';
 
 		return $sql;
 	}
@@ -86,8 +86,8 @@ class F0FModelFieldDate extends F0FModelFieldText
 			$extra = '=';
 		}
 
-		$sql = '((' . $this->getFieldName() . ' <' . $extra . ' ' . $from . ') AND ';
-		$sql .= '(' . $this->getFieldName() . ' >' . $extra . ' ' . $to . '))';
+		$sql = '((' . $this->getFieldName() . ' <' . $extra . ' "' . $from . '") OR ';
+		$sql .= '(' . $this->getFieldName() . ' >' . $extra . ' "' . $to . '"))';
 
 		return $sql;
 	}
@@ -128,6 +128,43 @@ class F0FModelFieldDate extends F0FModelFieldText
 
 		$sql = '(' . $this->getFieldName() . ' >' . $extra . ' ' . $function;
 		$sql .= '(' . $this->getFieldName() . ', INTERVAL ' . $interval['value'] . ' ' . $interval['unit'] . '))';
+
+		return $sql;
+	}
+
+	/**
+	 * Perform a between limits match. When $include is true
+	 * the condition tested is:
+	 * $from <= VALUE <= $to
+	 * When $include is false the condition tested is:
+	 * $from < VALUE < $to
+	 *
+	 * @param   mixed    $from     The lowest value to compare to
+	 * @param   mixed    $to       The higherst value to compare to
+	 * @param   boolean  $include  Should we include the boundaries in the search?
+	 *
+	 * @return  string  The SQL where clause for this search
+	 */
+	public function range($from, $to, $include = true)
+	{
+		if ($this->isEmpty($from) && $this->isEmpty($to))
+		{
+			return '';
+		}
+
+		$extra = '';
+
+		if ($include)
+		{
+			$extra = '=';
+		}
+
+		if ($from)
+			$sql[] = '(' . $this->getFieldName() . ' >' . $extra . ' "' . $from . '")';
+		if ($to)
+			$sql[] = '(' . $this->getFieldName() . ' <' . $extra . ' "' . $to . '")';
+
+		$sql = '(' . implode(' AND ', $sql) . ')';
 
 		return $sql;
 	}

--- a/fof/model/field/number.php
+++ b/fof/model/field/number.php
@@ -88,7 +88,7 @@ class F0FModelFieldNumber extends F0FModelField
 			$extra = '=';
 		}
 
-		$sql = '((' . $this->getFieldName() . ' <' . $extra . ' ' . $from . ') AND ';
+		$sql = '((' . $this->getFieldName() . ' <' . $extra . ' ' . $from . ') OR ';
 		$sql .= '(' . $this->getFieldName() . ' >' . $extra . ' ' . $to . '))';
 
 		return $sql;
@@ -124,6 +124,74 @@ class F0FModelFieldNumber extends F0FModelField
 
 		$sql = '((' . $this->getFieldName() . ' >' . $extra . ' ' . $from . ') AND ';
 		$sql .= '(' . $this->getFieldName() . ' <' . $extra . ' ' . $to . '))';
+
+		return $sql;
+	}
+
+	/**
+	 * Perform a range limits match. When $include is true
+	 * the condition tested is:
+	 * $from <= VALUE <= $to
+	 * When $include is false the condition tested is:
+	 * $from < VALUE < $to
+	 *
+	 * @param   mixed    $from     The lowest value to compare to
+	 * @param   mixed    $to       The higherst value to compare to
+	 * @param   boolean  $include  Should we include the boundaries in the search?
+	 *
+	 * @return  string  The SQL where clause for this search
+	 */
+	public function range($from, $to, $include = true)
+	{
+		if ($this->isEmpty($from) && $this->isEmpty($to))
+		{
+			return '';
+		}
+
+		$extra = '';
+
+		if ($include)
+		{
+			$extra = '=';
+		}
+
+		if ($from)
+			$sql[] = '(' . $this->getFieldName() . ' >' . $extra . ' ' . $from . ')';
+		if ($to)
+			$sql[] = '(' . $this->getFieldName() . ' <' . $extra . ' ' . $to . ')';
+
+		$sql = '(' . implode(' AND ', $sql) . ')';
+
+		return $sql;
+	}
+
+	/**
+	 * Perform an interval match. It's similar to a 'between' match, but the
+	 * from and to values are calculated based on $value and $interval:
+	 * $value - $interval < VALUE < $value + $interval
+	 *
+	 * @param   integer|float  $value     The starting value of the search space
+	 * @param   integer|float  $interval  The interval period of the search space
+	 * @param   boolean        $include   Should I include the boundaries in the search?
+	 *
+	 * @return  string  The SQL where clause
+	 */
+	public function modulo($value, $interval, $include = true)
+	{
+		if ($this->isEmpty($value) || $this->isEmpty($interval))
+		{
+			return '';
+		}
+
+		$extra = '';
+
+		if ($include)
+		{
+			$extra = '=';
+		}
+
+		$sql = '(' . $this->getFieldName() . ' >' . $extra . ' ' . $value . ' AND ';
+		$sql .= '(' . $this->getFieldName() . ' - ' . $value . ') % ' . $interval . ' = 0)';
 
 		return $sql;
 	}

--- a/fof/model/field/text.php
+++ b/fof/model/field/text.php
@@ -114,4 +114,32 @@ class F0FModelFieldText extends F0FModelField
 	{
 		return '';
 	}
+
+	/**
+	 * Dummy method; this search makes no sense for text fields
+	 *
+	 * @param   mixed    $from     Ignored
+	 * @param   mixed    $to       Ignored
+	 * @param   boolean  $include  Ignored
+	 *
+	 * @return  string  Empty string
+	 */
+	public function range($from, $to, $include = false)
+	{
+		return '';
+	}
+
+	/**
+	 * Dummy method; this search makes no sense for text fields
+	 *
+	 * @param   mixed    $from     Ignored
+	 * @param   mixed    $to       Ignored
+	 * @param   boolean  $include  Ignored
+	 *
+	 * @return  string  Empty string
+	 */
+	public function modulo($from, $to, $include = false)
+	{
+		return '';
+	}
 }


### PR DESCRIPTION
There,
1. Fixed the documentation
2. Fixed the outside (change AND -> OR)
3. Fixed date filter (we need quote in MySQL date)
4. Added range filter for date and number (same as between, but can have only `from` or `to`)
5. Added modue filter for number (conform to the old interval documentation)
6. My editor remove automaticaly the white spaces at the end of line... ^^'
