### PR TITLE
Added emptynonzero model behavior

### DIFF
--- a/documentation/fof-guide.xml
+++ b/documentation/fof-guide.xml
@@ -1349,6 +1349,21 @@ function postflight($type, $parent)
             </variablelist>
           </section>
 
+          <section xml:id="fofmodel-behaviours-enabled">
+            <title>emptynonzero.php</title>
+
+            <para>Adding this behaviour to a model object will extent the
+            <code>filters</code> behavior and allows FOF to not empty zero value.
+            For example, if you pass &amp;foobar=0 in the URL then the SQL query
+            used to fetch the items list will be filtered by the rows where
+            the foobar column is set to 0. Without this behavior the column
+            foobar will be considered as empty.</para>
+
+            <important>
+              <para>This behaviour requires the <code>filters</code> behavior.</para>
+            </important>
+          </section>
+
           <section xml:id="fofmodel-behaviours-language">
             <title>language</title>
 

--- a/fof/model/behavior/emptynonzero.php
+++ b/fof/model/behavior/emptynonzero.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     FrameworkOnFramework
+ * @subpackage  model
+ * @copyright   Copyright (C) 2010 - 2014 Akeeba Ltd. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+// Protect from unauthorized access
+defined('F0F_INCLUDED') or die;
+
+/**
+ * FrameworkOnFramework model behavior class
+ *
+ * @package  FrameworkOnFramework
+ * @since    2.1
+ */
+class F0FModelBehaviorEmptynonzero extends F0FModelBehavior
+{
+	/**
+	 * This event runs when we are building the query used to fetch a record
+	 * list in a model
+	 *
+	 * @param   F0FModel        &$model  The model which calls this event
+	 * @param   JDatabaseQuery  &$query  The query being built
+	 *
+	 * @return  void
+	 */
+	public function onBeforeBuildQuery(&$model, &$query)
+	{
+		$model->setState('_emptynonzero', '1');
+	}
+}

--- a/fof/model/behavior/filters.php
+++ b/fof/model/behavior/filters.php
@@ -32,6 +32,8 @@ class F0FModelBehaviorFilters extends F0FModelBehavior
 		$tableKey = $table->getKeyName();
 		$db = $model->getDBO();
 
+		$filterzero = $model->getState('_emptynonzero', null);
+
 		$fields = $model->getTableFields();
 
 		foreach ($fields as $fieldname => $fieldtype)
@@ -39,6 +41,7 @@ class F0FModelBehaviorFilters extends F0FModelBehavior
 			$field = new stdClass;
 			$field->name = $fieldname;
 			$field->type = $fieldtype;
+			$field->filterzero = $filterzero;
 
 			$filterName = ($field->name == $tableKey) ? 'id' : $field->name;
 			$filterState = $model->getState($filterName, null);

--- a/fof/model/field.php
+++ b/fof/model/field.php
@@ -60,6 +60,7 @@ abstract class F0FModelField
 
 		$this->name = $field->name;
 		$this->type = $field->type;
+		$this->filterzero = $field->filterzero;
 		$this->table_alias = $table_alias;
 	}
 
@@ -72,7 +73,8 @@ abstract class F0FModelField
 	 */
 	public function isEmpty($value)
 	{
-		return ($value === $this->null_value) || empty($value);
+		return (($value === $this->null_value) || empty($value))
+			&& !($this->filterzero && $value === "0");
 	}
 
 	/**


### PR DESCRIPTION
Check if it is good for you.

I tested for you

``` php
        return (($value === $this->null_value) || empty($value))
            && !($this->filterzero && $value === "0");
```

Result:

```
// Value     Zero    Result
// NULL      0       (1 || 1) && !(0 && 0) = (1 || 1) && 1 = 1
// ""        0       (1 || 1) && !(0 && 0) = (1 || 1) && 1 = 1
// 0         0       (1 || 1) && !(0 && 1) = (1 || 1) && 1 = 1
// NULL      1       (1 || 1) && !(1 && 0) = (1 || 1) && 1 = 1
// ""        1       (1 || 1) && !(1 && 0) = (1 || 1) && 1 = 1
// 0         1       (1 || 1) && !(1 && 1) = (1 || 1) && 0 = 0
```

Where `Zero` is the behavior enabled or not.
