### PR TITLE
Fix calculating the default layout name

### DIFF
--- a/fof/controller/controller.php
+++ b/fof/controller/controller.php
@@ -1222,7 +1222,7 @@ class F0FController extends F0FUtilsObject
 
 		// Set the layout to form, if it's not set in the URL
 
-		if (is_null($this->layout))
+		if (!$this->layout)
 		{
 			$this->layout = 'form';
 		}


### PR DESCRIPTION
In the latest commits, the Strapper renderer automatically adds the `layout` hidden input field to the form.
90% of the time this field is empty, sadly in the controller we are checking if `$this->layout` is null.

This means that in browse views that use XML forms, when the user tries to add a new record he gets a not-so-nice white screen since FOF is trying to load the default layout.
