### PR TITLE
Using class variables instead of element attributes on Fields

### DIFF
--- a/fof/Form/Field/AccessLevel.php
+++ b/fof/Form/Field/AccessLevel.php
@@ -100,7 +100,7 @@ class AccessLevel extends \JFormFieldAccessLevel implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		$params = $this->getOptions();
 
@@ -144,7 +144,7 @@ class AccessLevel extends \JFormFieldAccessLevel implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? (string) $this->class : '';
 
 		$params = $this->getOptions();
 

--- a/fof/Form/Field/Button.php
+++ b/fof/Form/Field/Button.php
@@ -121,9 +121,9 @@ class Button extends Text implements FieldInterface
 			$type = 'button';
 
 		$text    = $this->element['text'];
-		$class   = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class   = $this->class ? $this->class : '';
 		$icon    = $this->element['icon'] ? (string) $this->element['icon'] : '';
-		$onclick = $this->element['onclick'] ? 'onclick="' . (string) $this->element['onclick'] . '"' : '';
+		$onclick = $this->onclick ? 'onclick="' . $this->onclick . '"' : '';
 		$url     = $this->element['url'] ? 'href="' . $this->parseFieldTags((string) $this->element['url']) . '"' : '';
 		$title   = $this->element['title'] ? 'title="' . JText::_((string) $this->element['title']) . '"' : '';
 

--- a/fof/Form/Field/CacheHandler.php
+++ b/fof/Form/Field/CacheHandler.php
@@ -98,7 +98,7 @@ class CacheHandler extends \JFormFieldCacheHandler implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class CacheHandler extends \JFormFieldCacheHandler implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Calendar.php
+++ b/fof/Form/Field/Calendar.php
@@ -130,7 +130,7 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 	{
 		// Initialize some field attributes.
 		$format  = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
-		$class   = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class   = $this->class ? $this->class : '';
 		$default = $this->element['default'] ? (string) $this->element['default'] : '';
 
 		// PHP date doesn't use percentages (%) for the format, but the calendar Javascript
@@ -187,9 +187,9 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 			// Build the attributes array.
 			$attributes = array();
 
-			if ($this->element['size'])
+			if ($this->size])
 			{
-				$attributes['size'] = (int) $this->element['size'];
+				$attributes['size'] = $this->size;
 			}
 
 			if ($this->element['maxlength'])
@@ -197,24 +197,24 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 				$attributes['maxlength'] = (int) $this->element['maxlength'];
 			}
 
-			if ($this->element['class'])
+			if ($this->class)
 			{
-				$attributes['class'] = (string) $this->element['class'];
+				$attributes['class'] = $this->class;
 			}
 
-			if ((string) $this->element['readonly'] == 'true')
+			if ($this->readonly)
 			{
 				$attributes['readonly'] = 'readonly';
 			}
 
-			if ((string) $this->element['disabled'] == 'true')
+			if ($this->disabled)
 			{
 				$attributes['disabled'] = 'disabled';
 			}
 
-			if ($this->element['onchange'])
+			if ($this->onchange)
 			{
-				$attributes['onchange'] = (string) $this->element['onchange'];
+				$attributes['onchange'] = $this->onchange;
 			}
 
 			if ($this->required)

--- a/fof/Form/Field/Checkbox.php
+++ b/fof/Form/Field/Checkbox.php
@@ -98,10 +98,10 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$value = $this->element['value'] ? (string) $this->element['value'] : '1';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
+		$class    = $this->class ? ' class="' . $this->class . '"' : '';
+		$value    = $this->element['value'] ? (string) $this->element['value'] : '1';
+		$disabled = $this->disabled ? ' disabled="disabled"' : '';
+		$onclick  = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
 		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		if (empty($this->value))
@@ -129,10 +129,10 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
-		$value = $this->element['value'] ? (string) $this->element['value'] : '1';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
+		$class    = $this->class ? $this->class : '';
+		$value    = $this->element['value'] ? (string) $this->element['value'] : '1';
+		$disabled = $this->disabled ? ' disabled="disabled"' : '';
+		$onclick  = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
 		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		if (empty($this->value))

--- a/fof/Form/Field/Checkboxes.php
+++ b/fof/Form/Field/Checkboxes.php
@@ -112,7 +112,7 @@ class Checkboxes extends \JFormFieldCheckboxes implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class     = $this->element['class'] ? (string) $this->element['class'] : $this->id;
+		$class     = $this->class ? (string) $this->class : $this->id;
 		$translate = $this->element['translate'] ? (string) $this->element['translate'] : false;
 
 		$html = '<span class="' . $class . '">';
@@ -136,21 +136,5 @@ class Checkboxes extends \JFormFieldCheckboxes implements FieldInterface
 		$html .= '</span>';
 
 		return $html;
-	}
-
-	/**
-	 * Get the rendering of this field type for static display, e.g. in a single
-	 * item view (typically a "read" task).
-	 *
-	 * @since 2.0
-	 *
-	 * @return  string  The field HTML
-	 */
-	public function getInput()
-	{
-		// Used for J! 2.5 compatibility
-		$this->value = !is_array($this->value) ? explode(',', $this->value) : $this->value;
-
-		return parent::getInput();
 	}
 }

--- a/fof/Form/Field/Components.php
+++ b/fof/Form/Field/Components.php
@@ -106,7 +106,7 @@ class Components extends \JFormFieldList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -123,7 +123,7 @@ class Components extends \JFormFieldList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? (string) $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Editor.php
+++ b/fof/Form/Field/Editor.php
@@ -98,7 +98,7 @@ class Editor extends \JFormFieldEditor implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<div id="' . $this->id . '" ' . $class . '>' . $this->value . '</div>';
 	}
@@ -113,7 +113,7 @@ class Editor extends \JFormFieldEditor implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<div class="' . $this->id . ' ' . $class . '">' . $this->value . '</div>';
 	}

--- a/fof/Form/Field/Email.php
+++ b/fof/Form/Field/Email.php
@@ -99,7 +99,7 @@ class Email extends \JFormFieldEMail implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 		$dolink = $this->element['show_link'] == 'true';
 		$empty_replacement = '';
 
@@ -142,9 +142,9 @@ class Email extends \JFormFieldEMail implements FieldInterface
 		$empty_replacement = '';
 
 		// Get field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = (string) $this->element['class'];
+			$class = $this->class;
 		}
 
 		if ($this->element['show_link'] == 'true')

--- a/fof/Form/Field/GenericList.php
+++ b/fof/Form/Field/GenericList.php
@@ -100,7 +100,7 @@ class GenericList extends \JFormFieldList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(self::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -120,7 +120,7 @@ class GenericList extends \JFormFieldList implements FieldInterface
 		$show_link         = false;
 		$link_url          = '';
 
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		if ($this->element['show_link'] == 'true')
 		{

--- a/fof/Form/Field/GroupedButton.php
+++ b/fof/Form/Field/GroupedButton.php
@@ -124,7 +124,7 @@ class GroupedButton extends \JFormFieldText implements FieldInterface
 	 */
 	public function getInput()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		$html = '<div id="' . $this->id . '" class="btn-group ' . $class . '">';
 

--- a/fof/Form/Field/GroupedList.php
+++ b/fof/Form/Field/GroupedList.php
@@ -99,7 +99,7 @@ class GroupedList extends \JFormFieldGroupedList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		$selected = self::getOptionName($this->getGroups(), $this->value);
 
@@ -129,7 +129,7 @@ class GroupedList extends \JFormFieldGroupedList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		$selected = self::getOptionName($this->getGroups(), $this->value);
 

--- a/fof/Form/Field/ImageList.php
+++ b/fof/Form/Field/ImageList.php
@@ -104,9 +104,9 @@ class ImageList extends \JFormFieldImageList implements FieldInterface
 			'id' => $this->id
 		);
 
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$imgattr['class'] = (string) $this->element['class'];
+			$imgattr['class'] = $this->class;
 		}
 
 		if ($this->element['style'])

--- a/fof/Form/Field/Integer.php
+++ b/fof/Form/Field/Integer.php
@@ -98,7 +98,7 @@ class Integer extends \JFormFieldInteger implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class Integer extends \JFormFieldInteger implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Language.php
+++ b/fof/Form/Field/Language.php
@@ -121,7 +121,7 @@ class Language extends \JFormFieldLanguage implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -138,7 +138,7 @@ class Language extends \JFormFieldLanguage implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Media.php
+++ b/fof/Form/Field/Media.php
@@ -104,9 +104,9 @@ class Media extends \JFormFieldMedia implements FieldInterface
 			'id' => $this->id
 		);
 
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$imgattr['class'] = (string) $this->element['class'];
+			$imgattr['class'] = $this->class;
 		}
 
 		if ($this->element['style'])

--- a/fof/Form/Field/Model.php
+++ b/fof/Form/Field/Model.php
@@ -101,7 +101,7 @@ class Model extends GenericList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -125,9 +125,9 @@ class Model extends GenericList implements FieldInterface
 		$empty_replacement	= '';
 
 		// Get field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = (string) $this->element['class'];
+			$class = $this->class;
 		}
 
 		if ($this->element['format'])

--- a/fof/Form/Field/Ordering.php
+++ b/fof/Form/Field/Ordering.php
@@ -164,7 +164,7 @@ class Ordering extends \JFormField implements FieldInterface
 			throw new DataModelRequired(__CLASS__);
 		}
 
-		$class = isset($this->element['class']) ? $this->element['class'] : 'input-mini';
+		$class = isset($this->class) ? $this->class : 'input-mini';
 		$icon  = isset($this->element['icon']) ? $this->element['icon'] : 'icon-menu';
 
 		$html = '';

--- a/fof/Form/Field/Password.php
+++ b/fof/Form/Field/Password.php
@@ -98,7 +98,7 @@ class Password extends \JFormFieldPassword implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Plugins.php
+++ b/fof/Form/Field/Plugins.php
@@ -98,7 +98,7 @@ class Plugins extends \JFormFieldPlugins implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class Plugins extends \JFormFieldPlugins implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Published.php
+++ b/fof/Form/Field/Published.php
@@ -187,7 +187,7 @@ class Published extends \JFormFieldList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Radio.php
+++ b/fof/Form/Field/Radio.php
@@ -98,7 +98,7 @@ class Radio extends \JFormFieldRadio implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class Radio extends \JFormFieldRadio implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Relation.php
+++ b/fof/Form/Field/Relation.php
@@ -42,7 +42,7 @@ class Relation extends GenericList
 	 */
 	public function getRepeatable()
 	{
-		$class         = $this->element['class'] ? (string) $this->element['class'] : $this->id;
+		$class         = $this->class ? $this->class : $this->id;
 		$relationclass = $this->element['relationclass'] ? (string) $this->element['relationclass'] : '';
 		$value_field   = $this->element['value_field'] ? (string) $this->element['value_field'] : 'title';
 		$translate     = $this->element['translate'] ? (string) $this->element['translate'] : false;

--- a/fof/Form/Field/Rules.php
+++ b/fof/Form/Field/Rules.php
@@ -23,36 +23,36 @@ defined('_JEXEC') or die;
  */
 class Rules extends \JFormFieldRules implements FieldInterface
 {
-    /**
-     * @var  string  Static field output
-     */
-    protected $static;
+	/**
+	 * @var  string  Static field output
+	 */
+	protected $static;
 
-    /**
-     * @var  string  Repeatable field output
-     */
-    protected $repeatable;
+	/**
+	 * @var  string  Repeatable field output
+	 */
+	protected $repeatable;
 
-    /**
-     * The Form object of the form attached to the form field.
-     *
-     * @var    Form
-     */
-    protected $form;
+	/**
+	 * The Form object of the form attached to the form field.
+	 *
+	 * @var    Form
+	 */
+	protected $form;
 
-    /**
-     * A monotonically increasing number, denoting the row number in a repeatable view
-     *
-     * @var  int
-     */
-    public $rowid;
+	/**
+	 * A monotonically increasing number, denoting the row number in a repeatable view
+	 *
+	 * @var  int
+	 */
+	public $rowid;
 
-    /**
-     * The item being rendered in a repeatable form field
-     *
-     * @var  DataModel
-     */
-    public $item;
+	/**
+	 * The item being rendered in a repeatable form field
+	 *
+	 * @var  DataModel
+	 */
+	public $item;
 
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
@@ -108,551 +108,271 @@ class Rules extends \JFormFieldRules implements FieldInterface
 		return '';
 	}
 
-    /**
+	/**
 	 * At the timing of this writing (2013-12-03), the Joomla "rules" field is buggy. When you are
 	 * dealing with a new record it gets the default permissions from the root asset node, which
 	 * is fine for the default permissions of Joomla articles, but unsuitable for third party software.
 	 * We had to copy & paste the whole code, since we can't "inject" the correct asset id if one is
 	 * not found. Our fixes are surrounded by `FOF Library fix` remarks.
-     *
-     * @return  string  The input field's HTML for this field type
-     */
-    public function getInput()
-    {
-        if (version_compare(JVERSION, '3.0', 'ge'))
-        {
-            return $this->getInput3x();
-        }
-        else
-        {
-            return $this->getInput25();
-        }
-    }
-
-    protected function getInput25()
-    {
-        JHtml::_('behavior.tooltip');
-
-        // Initialise some field attributes.
-        $section = $this->element['section'] ? (string) $this->element['section'] : '';
-        $component = $this->element['component'] ? (string) $this->element['component'] : '';
-        $assetField = $this->element['asset_field'] ? (string) $this->element['asset_field'] : 'asset_id';
-
-        // Get the actions for the asset.
-        $actions = \JAccess::getActions($component, $section);
-
-        // Iterate over the children and add to the actions.
-        /** @var \SimpleXMLElement $el */
-        foreach ($this->element->children() as $el)
-        {
-            if ($el->getName() == 'action')
-            {
-                $actions[] = (object) array('name' => (string) $el['name'], 'title' => (string) $el['title'],
-                    'description' => (string) $el['description']);
-            }
-        }
-
-        // Get the explicit rules for this asset.
-        if ($section == 'component')
-        {
-            // Need to find the asset id by the name of the component.
-            $db    = $this->form->getContainer()->platform->getDbo();
-            $query = $db->getQuery(true);
-            $query->select($db->quoteName('id'));
-            $query->from($db->quoteName('#__assets'));
-            $query->where($db->quoteName('name') . ' = ' . $db->quote($component));
-            $db->setQuery($query);
-            $assetId = (int) $db->loadResult();
-
-            if ($error = $db->getErrorMsg())
-            {
-                \JError::raiseNotice(500, $error);
-            }
-        }
-        else
-        {
-            // Find the asset id of the content.
-            // Note that for global configuration, com_config injects asset_id = 1 into the form.
-            $assetId = $this->form->getValue($assetField);
-
-            // ==== FOF Library fix - Start ====
-            // If there is no assetId (let's say we are dealing with a new record), let's ask the table
-            // to give it to us. Here you should implement your logic (ie getting default permissions from
-            // the component or from the category)
-            if(!$assetId)
-            {
-                $table   = $this->form->getModel();
-                $assetId = $table->getAssetParentId();
-            }
-            // ==== FOF Library fix - End   ====
-        }
-
-        // Use the compact form for the content rules (deprecated).
-        //if (!empty($component) && $section != 'component') {
-        //	return JHtml::_('rules.assetFormWidget', $actions, $assetId, $assetId ? null : $component, $this->name, $this->id);
-        //}
-
-        // Full width format.
-
-        // Get the rules for just this asset (non-recursive).
-        $assetRules = \JAccess::getAssetRules($assetId);
-
-        // Get the available user groups.
-        $groups = $this->getUserGroups();
-
-        // Build the form control.
-        $curLevel = 0;
-
-        // Prepare output
-        $html = array();
-        $html[] = '<div id="permissions-sliders" class="pane-sliders">';
-        $html[] = '<p class="rule-desc">' . JText::_('JLIB_RULES_SETTINGS_DESC') . '</p>';
-        $html[] = '<ul id="rules">';
-
-        // Start a row for each user group.
-        foreach ($groups as $group)
-        {
-            $difLevel = $group->level - $curLevel;
-
-            if ($difLevel > 0)
-            {
-                $html[] = '<li><ul>';
-            }
-            elseif ($difLevel < 0)
-            {
-                $html[] = str_repeat('</ul></li>', -$difLevel);
-            }
-
-            $html[] = '<li>';
-
-            $html[] = '<div class="panel">';
-            $html[] = '<h3 class="pane-toggler title"><a href="javascript:void(0);"><span>';
-            $html[] = str_repeat('<span class="level">|&ndash;</span> ', $curLevel = $group->level) . $group->text;
-            $html[] = '</span></a></h3>';
-            $html[] = '<div class="pane-slider content pane-hide">';
-            $html[] = '<div class="mypanel">';
-            $html[] = '<table class="group-rules">';
-            $html[] = '<thead>';
-            $html[] = '<tr>';
-
-            $html[] = '<th class="actions" id="actions-th' . $group->value . '">';
-            $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_ACTION') . '</span>';
-            $html[] = '</th>';
-
-            $html[] = '<th class="settings" id="settings-th' . $group->value . '">';
-            $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_SELECT_SETTING') . '</span>';
-            $html[] = '</th>';
-
-            // The calculated setting is not shown for the root group of global configuration.
-            $canCalculateSettings = ($group->parent_id || !empty($component));
-            if ($canCalculateSettings)
-            {
-                $html[] = '<th id="aclactionth' . $group->value . '">';
-                $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_CALCULATED_SETTING') . '</span>';
-                $html[] = '</th>';
-            }
-
-            $html[] = '</tr>';
-            $html[] = '</thead>';
-            $html[] = '<tbody>';
-
-            foreach ($actions as $action)
-            {
-                $html[] = '<tr>';
-                $html[] = '<td headers="actions-th' . $group->value . '">';
-                $html[] = '<label class="hasTip" for="' . $this->id . '_' . $action->name . '_' . $group->value . '" title="'
-                    . htmlspecialchars(JText::_($action->title) . '::' . JText::_($action->description), ENT_COMPAT, 'UTF-8') . '">';
-                $html[] = JText::_($action->title);
-                $html[] = '</label>';
-                $html[] = '</td>';
-
-                $html[] = '<td headers="settings-th' . $group->value . '">';
-
-                $html[] = '<select name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id . '_' . $action->name
-                    . '_' . $group->value . '" title="'
-                    . JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
-
-                $inheritedRule = \JAccess::checkGroup($group->value, $action->name, $assetId);
-
-                // Get the actual setting for the action for this group.
-                $assetRule = $assetRules->allow($action->name, $group->value);
-
-                // Build the dropdowns for the permissions sliders
-
-                // The parent group has "Not Set", all children can rightly "Inherit" from that.
-                $html[] = '<option value=""' . ($assetRule === null ? ' selected="selected"' : '') . '>'
-                    . JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
-                $html[] = '<option value="1"' . ($assetRule === true ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_ALLOWED')
-                    . '</option>';
-                $html[] = '<option value="0"' . ($assetRule === false ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_DENIED')
-                    . '</option>';
-
-                $html[] = '</select>&#160; ';
-
-                // If this asset's rule is allowed, but the inherited rule is deny, we have a conflict.
-                if (($assetRule === true) && ($inheritedRule === false))
-                {
-                    $html[] = JText::_('JLIB_RULES_CONFLICT');
-                }
-
-                $html[] = '</td>';
-
-                // Build the Calculated Settings column.
-                // The inherited settings column is not displayed for the root group in global configuration.
-                if ($canCalculateSettings)
-                {
-                    $html[] = '<td headers="aclactionth' . $group->value . '">';
-
-                    // This is where we show the current effective settings considering currrent group, path and cascade.
-                    // Check whether this is a component or global. Change the text slightly.
-
-                    if (\JAccess::checkGroup($group->value, 'core.admin', $assetId) !== true)
-                    {
-                        if ($inheritedRule === null)
-                        {
-                            $html[] = '<span class="icon-16-unset">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === true)
-                        {
-                            $html[] = '<span class="icon-16-allowed">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === false)
-                        {
-                            if ($assetRule === false)
-                            {
-                                $html[] = '<span class="icon-16-denied">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
-                            }
-                            else
-                            {
-                                $html[] = '<span class="icon-16-denied"><span class="icon-16-locked">' . JText::_('JLIB_RULES_NOT_ALLOWED_LOCKED')
-                                    . '</span></span>';
-                            }
-                        }
-                    }
-                    elseif (!empty($component))
-                    {
-                        $html[] = '<span class="icon-16-allowed"><span class="icon-16-locked">' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
-                            . '</span></span>';
-                    }
-                    else
-                    {
-                        // Special handling for  groups that have global admin because they can't  be denied.
-                        // The admin rights can be changed.
-                        if ($action->name === 'core.admin')
-                        {
-                            $html[] = '<span class="icon-16-allowed">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === false)
-                        {
-                            // Other actions cannot be changed.
-                            $html[] = '<span class="icon-16-denied"><span class="icon-16-locked">'
-                                . JText::_('JLIB_RULES_NOT_ALLOWED_ADMIN_CONFLICT') . '</span></span>';
-                        }
-                        else
-                        {
-                            $html[] = '<span class="icon-16-allowed"><span class="icon-16-locked">' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
-                                . '</span></span>';
-                        }
-                    }
-
-                    $html[] = '</td>';
-                }
-
-                $html[] = '</tr>';
-            }
-
-            $html[] = '</tbody>';
-            $html[] = '</table></div>';
-
-            $html[] = '</div></div>';
-            $html[] = '</li>';
-
-        }
-
-        $html[] = str_repeat('</ul></li>', $curLevel);
-        $html[] = '</ul><div class="rule-notes">';
-        if ($section == 'component' || $section == null)
-        {
-            $html[] = JText::_('JLIB_RULES_SETTING_NOTES');
-        }
-        else
-        {
-            $html[] = JText::_('JLIB_RULES_SETTING_NOTES_ITEM');
-        }
-        $html[] = '</div></div>';
-
-
-        $js = "window.addEvent('domready', function(){ new Fx.Accordion($$('div#permissions-sliders.pane-sliders .panel h3.pane-toggler'),"
-            . "$$('div#permissions-sliders.pane-sliders .panel div.pane-slider'), {onActive: function(toggler, i) {toggler.addClass('pane-toggler-down');"
-            . "toggler.removeClass('pane-toggler');i.addClass('pane-down');i.removeClass('pane-hide');Cookie.write('jpanesliders_permissions-sliders"
-            . $component
-            . "',$$('div#permissions-sliders.pane-sliders .panel h3').indexOf(toggler));},"
-            . "onBackground: function(toggler, i) {toggler.addClass('pane-toggler');toggler.removeClass('pane-toggler-down');i.addClass('pane-hide');"
-            . "i.removeClass('pane-down');}, duration: 300, display: "
-            . $this->form->getContainer()->input->getInt('jpanesliders_permissions-sliders' . $component, 0, 'cookie') . ", show: "
-            . $this->form->getContainer()->input->getInt('jpanesliders_permissions-sliders' . $component, 0, 'cookie') . ", alwaysHide:true, opacity: false}); });";
-
-        \JFactory::getDocument()->addScriptDeclaration($js);
-
-        return implode("\n", $html);
-    }
-
-    protected function getInput3x()
-    {
-        JHtml::_('bootstrap.tooltip');
-
-        // Initialise some field attributes.
-        $section    = $this->section;
-        $component  = $this->component;
-        $assetField = $this->assetField;
-
-        // Get the actions for the asset.
-        $actions = \JAccess::getActions($component, $section);
-
-        // Iterate over the children and add to the actions.
-        /** @var \SimpleXMLElement $el */
-        foreach ($this->element->children() as $el)
-        {
-            if ($el->getName() == 'action')
-            {
-                $actions[] = (object) array('name' => (string) $el['name'], 'title' => (string) $el['title'],
-                    'description' => (string) $el['description']);
-            }
-        }
-
-        // Get the explicit rules for this asset.
-        if ($section == 'component')
-        {
-            // Need to find the asset id by the name of the component.
-            $db    = $this->form->getContainer()->platform->getDbo();
-            $query = $db->getQuery(true)
-                        ->select($db->quoteName('id'))
-                        ->from($db->quoteName('#__assets'))
-                        ->where($db->quoteName('name') . ' = ' . $db->quote($component));
-
-            $assetId = (int) $db->setQuery($query)->loadResult();
-        }
-        else
-        {
-            // Find the asset id of the content.
-            // Note that for global configuration, com_config injects asset_id = 1 into the form.
-            $assetId = $this->form->getValue($assetField);
-
-            // ==== FOF Library fix - Start ====
-            // If there is no assetId (let's say we are dealing with a new record), let's ask the table
-            // to give it to us. Here you should implement your logic (ie getting default permissions from
-            // the component or from the category)
-            if(!$assetId)
-            {
-                $table   = $this->form->getModel();
-                $assetId = $table->getAssetParentId();
-            }
-            // ==== FOF Library fix - End   ====
-        }
-
-        // Full width format.
-
-        // Get the rules for just this asset (non-recursive).
-        $assetRules = \JAccess::getAssetRules($assetId);
-
-        // Get the available user groups.
-        $groups = $this->getUserGroups();
-
-        // Prepare output
-        $html = array();
-
-        // Description
-        $html[] = '<p class="rule-desc">' . JText::_('JLIB_RULES_SETTINGS_DESC') . '</p>';
-
-        // Begin tabs
-        $html[] = '<div id="permissions-sliders" class="tabbable tabs-left">';
-
-        // Building tab nav
-        $html[] = '<ul class="nav nav-tabs">';
-
-        foreach ($groups as $group)
-        {
-            // Initial Active Tab
-            $active = "";
-
-            if ($group->value == 1)
-            {
-                $active = "active";
-            }
-
-            $html[] = '<li class="' . $active . '">';
-            $html[] = '<a href="#permission-' . $group->value . '" data-toggle="tab">';
-            $html[] = str_repeat('<span class="level">&ndash;</span> ', $curLevel = $group->level) . $group->text;
-            $html[] = '</a>';
-            $html[] = '</li>';
-        }
-
-        $html[] = '</ul>';
-
-        $html[] = '<div class="tab-content">';
-
-        // Start a row for each user group.
-        foreach ($groups as $group)
-        {
-            // Initial Active Pane
-            $active = "";
-
-            if ($group->value == 1)
-            {
-                $active = " active";
-            }
-
-            $html[] = '<div class="tab-pane' . $active . '" id="permission-' . $group->value . '">';
-            $html[] = '<table class="table table-striped">';
-            $html[] = '<thead>';
-            $html[] = '<tr>';
-
-            $html[] = '<th class="actions" id="actions-th' . $group->value . '">';
-            $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_ACTION') . '</span>';
-            $html[] = '</th>';
-
-            $html[] = '<th class="settings" id="settings-th' . $group->value . '">';
-            $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_SELECT_SETTING') . '</span>';
-            $html[] = '</th>';
-
-            // The calculated setting is not shown for the root group of global configuration.
-            $canCalculateSettings = ($group->parent_id || !empty($component));
-
-            if ($canCalculateSettings)
-            {
-                $html[] = '<th id="aclactionth' . $group->value . '">';
-                $html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_CALCULATED_SETTING') . '</span>';
-                $html[] = '</th>';
-            }
-
-            $html[] = '</tr>';
-            $html[] = '</thead>';
-            $html[] = '<tbody>';
-
-            foreach ($actions as $action)
-            {
-                $html[] = '<tr>';
-                $html[] = '<td headers="actions-th' . $group->value . '">';
-                $html[] = '<label for="' . $this->id . '_' . $action->name . '_' . $group->value . '" class="hasTooltip" title="'
-                    . htmlspecialchars(JText::_($action->title) . ' ' . JText::_($action->description), ENT_COMPAT, 'UTF-8') . '">';
-                $html[] = JText::_($action->title);
-                $html[] = '</label>';
-                $html[] = '</td>';
-
-                $html[] = '<td headers="settings-th' . $group->value . '">';
-
-                $html[] = '<select class="input-small" name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id . '_' . $action->name
-                    . '_' . $group->value . '" title="'
-                    . JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
-
-                $inheritedRule = \JAccess::checkGroup($group->value, $action->name, $assetId);
-
-                // Get the actual setting for the action for this group.
-                $assetRule = $assetRules->allow($action->name, $group->value);
-
-                // Build the dropdowns for the permissions sliders
-
-                // The parent group has "Not Set", all children can rightly "Inherit" from that.
-                $html[] = '<option value=""' . ($assetRule === null ? ' selected="selected"' : '') . '>'
-                    . JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
-                $html[] = '<option value="1"' . ($assetRule === true ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_ALLOWED')
-                    . '</option>';
-                $html[] = '<option value="0"' . ($assetRule === false ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_DENIED')
-                    . '</option>';
-
-                $html[] = '</select>&#160; ';
-
-                // If this asset's rule is allowed, but the inherited rule is deny, we have a conflict.
-                if (($assetRule === true) && ($inheritedRule === false))
-                {
-                    $html[] = JText::_('JLIB_RULES_CONFLICT');
-                }
-
-                $html[] = '</td>';
-
-                // Build the Calculated Settings column.
-                // The inherited settings column is not displayed for the root group in global configuration.
-                if ($canCalculateSettings)
-                {
-                    $html[] = '<td headers="aclactionth' . $group->value . '">';
-
-                    // This is where we show the current effective settings considering currrent group, path and cascade.
-                    // Check whether this is a component or global. Change the text slightly.
-
-                    if (\JAccess::checkGroup($group->value, 'core.admin', $assetId) !== true)
-                    {
-                        if ($inheritedRule === null)
-                        {
-                            $html[] = '<span class="label label-important">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === true)
-                        {
-                            $html[] = '<span class="label label-success">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === false)
-                        {
-                            if ($assetRule === false)
-                            {
-                                $html[] = '<span class="label label-important">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
-                            }
-                            else
-                            {
-                                $html[] = '<span class="label"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_NOT_ALLOWED_LOCKED')
-                                    . '</span>';
-                            }
-                        }
-                    }
-                    elseif (!empty($component))
-                    {
-                        $html[] = '<span class="label label-success"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
-                            . '</span>';
-                    }
-                    else
-                    {
-                        // Special handling for  groups that have global admin because they can't  be denied.
-                        // The admin rights can be changed.
-                        if ($action->name === 'core.admin')
-                        {
-                            $html[] = '<span class="label label-success">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
-                        }
-                        elseif ($inheritedRule === false)
-                        {
-                            // Other actions cannot be changed.
-                            $html[] = '<span class="label label-important"><i class="icon-lock icon-white"></i> '
-                                . JText::_('JLIB_RULES_NOT_ALLOWED_ADMIN_CONFLICT') . '</span>';
-                        }
-                        else
-                        {
-                            $html[] = '<span class="label label-success"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
-                                . '</span>';
-                        }
-                    }
-
-                    $html[] = '</td>';
-                }
-
-                $html[] = '</tr>';
-            }
-
-            $html[] = '</tbody>';
-            $html[] = '</table></div>';
-        }
-
-        $html[] = '</div></div>';
-
-        $html[] = '<div class="alert">';
-
-        if ($section == 'component' || $section == null)
-        {
-            $html[] = JText::_('JLIB_RULES_SETTING_NOTES');
-        }
-        else
-        {
-            $html[] = JText::_('JLIB_RULES_SETTING_NOTES_ITEM');
-        }
-
-        $html[] = '</div>';
-
-        return implode("\n", $html);
-    }
+	 *
+	 * @return  string  The input field's HTML for this field type
+	 */
+	protected function getInput()
+	{
+		JHtml::_('bootstrap.tooltip');
+
+		// Initialise some field attributes.
+		$section    = $this->section;
+		$component  = $this->component;
+		$assetField = $this->assetField;
+
+		// Get the actions for the asset.
+		$actions = \JAccess::getActions($component, $section);
+
+		// Iterate over the children and add to the actions.
+		/** @var \SimpleXMLElement $el */
+		foreach ($this->element->children() as $el)
+		{
+			if ($el->getName() == 'action')
+			{
+				$actions[] = (object) array('name' => (string) $el['name'], 'title' => (string) $el['title'],
+					'description' => (string) $el['description']);
+			}
+		}
+
+		// Get the explicit rules for this asset.
+		if ($section == 'component')
+		{
+			// Need to find the asset id by the name of the component.
+			$db    = $this->form->getContainer()->platform->getDbo();
+			$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from($db->quoteName('#__assets'))
+						->where($db->quoteName('name') . ' = ' . $db->quote($component));
+
+			$assetId = (int) $db->setQuery($query)->loadResult();
+		}
+		else
+		{
+			// Find the asset id of the content.
+			// Note that for global configuration, com_config injects asset_id = 1 into the form.
+			$assetId = $this->form->getValue($assetField);
+
+			// ==== FOF Library fix - Start ====
+			// If there is no assetId (let's say we are dealing with a new record), let's ask the table
+			// to give it to us. Here you should implement your logic (ie getting default permissions from
+			// the component or from the category)
+			if(!$assetId)
+			{
+				$table   = $this->form->getModel();
+				$assetId = $table->getAssetParentId();
+			}
+			// ==== FOF Library fix - End   ====
+		}
+
+		// Full width format.
+
+		// Get the rules for just this asset (non-recursive).
+		$assetRules = \JAccess::getAssetRules($assetId);
+
+		// Get the available user groups.
+		$groups = $this->getUserGroups();
+
+		// Prepare output
+		$html = array();
+
+		// Description
+		$html[] = '<p class="rule-desc">' . JText::_('JLIB_RULES_SETTINGS_DESC') . '</p>';
+
+		// Begin tabs
+		$html[] = '<div id="permissions-sliders" class="tabbable tabs-left">';
+
+		// Building tab nav
+		$html[] = '<ul class="nav nav-tabs">';
+
+		foreach ($groups as $group)
+		{
+			// Initial Active Tab
+			$active = "";
+
+			if ($group->value == 1)
+			{
+				$active = "active";
+			}
+
+			$html[] = '<li class="' . $active . '">';
+			$html[] = '<a href="#permission-' . $group->value . '" data-toggle="tab">';
+			$html[] = str_repeat('<span class="level">&ndash;</span> ', $curLevel = $group->level) . $group->text;
+			$html[] = '</a>';
+			$html[] = '</li>';
+		}
+
+		$html[] = '</ul>';
+
+		$html[] = '<div class="tab-content">';
+
+		// Start a row for each user group.
+		foreach ($groups as $group)
+		{
+			// Initial Active Pane
+			$active = "";
+
+			if ($group->value == 1)
+			{
+				$active = " active";
+			}
+
+			$html[] = '<div class="tab-pane' . $active . '" id="permission-' . $group->value . '">';
+			$html[] = '<table class="table table-striped">';
+			$html[] = '<thead>';
+			$html[] = '<tr>';
+
+			$html[] = '<th class="actions" id="actions-th' . $group->value . '">';
+			$html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_ACTION') . '</span>';
+			$html[] = '</th>';
+
+			$html[] = '<th class="settings" id="settings-th' . $group->value . '">';
+			$html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_SELECT_SETTING') . '</span>';
+			$html[] = '</th>';
+
+			// The calculated setting is not shown for the root group of global configuration.
+			$canCalculateSettings = ($group->parent_id || !empty($component));
+
+			if ($canCalculateSettings)
+			{
+				$html[] = '<th id="aclactionth' . $group->value . '">';
+				$html[] = '<span class="acl-action">' . JText::_('JLIB_RULES_CALCULATED_SETTING') . '</span>';
+				$html[] = '</th>';
+			}
+
+			$html[] = '</tr>';
+			$html[] = '</thead>';
+			$html[] = '<tbody>';
+
+			foreach ($actions as $action)
+			{
+				$html[] = '<tr>';
+				$html[] = '<td headers="actions-th' . $group->value . '">';
+				$html[] = '<label for="' . $this->id . '_' . $action->name . '_' . $group->value . '" class="hasTooltip" title="'
+					. htmlspecialchars(JText::_($action->title) . ' ' . JText::_($action->description), ENT_COMPAT, 'UTF-8') . '">';
+				$html[] = JText::_($action->title);
+				$html[] = '</label>';
+				$html[] = '</td>';
+
+				$html[] = '<td headers="settings-th' . $group->value . '">';
+
+				$html[] = '<select class="input-small" name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id . '_' . $action->name
+					. '_' . $group->value . '" title="'
+					. JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
+
+				$inheritedRule = \JAccess::checkGroup($group->value, $action->name, $assetId);
+
+				// Get the actual setting for the action for this group.
+				$assetRule = $assetRules->allow($action->name, $group->value);
+
+				// Build the dropdowns for the permissions sliders
+
+				// The parent group has "Not Set", all children can rightly "Inherit" from that.
+				$html[] = '<option value=""' . ($assetRule === null ? ' selected="selected"' : '') . '>'
+					. JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
+				$html[] = '<option value="1"' . ($assetRule === true ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_ALLOWED')
+					. '</option>';
+				$html[] = '<option value="0"' . ($assetRule === false ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_DENIED')
+					. '</option>';
+
+				$html[] = '</select>&#160; ';
+
+				// If this asset's rule is allowed, but the inherited rule is deny, we have a conflict.
+				if (($assetRule === true) && ($inheritedRule === false))
+				{
+					$html[] = JText::_('JLIB_RULES_CONFLICT');
+				}
+
+				$html[] = '</td>';
+
+				// Build the Calculated Settings column.
+				// The inherited settings column is not displayed for the root group in global configuration.
+				if ($canCalculateSettings)
+				{
+					$html[] = '<td headers="aclactionth' . $group->value . '">';
+
+					// This is where we show the current effective settings considering currrent group, path and cascade.
+					// Check whether this is a component or global. Change the text slightly.
+
+					if (\JAccess::checkGroup($group->value, 'core.admin', $assetId) !== true)
+					{
+						if ($inheritedRule === null)
+						{
+							$html[] = '<span class="label label-important">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
+						}
+						elseif ($inheritedRule === true)
+						{
+							$html[] = '<span class="label label-success">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
+						}
+						elseif ($inheritedRule === false)
+						{
+							if ($assetRule === false)
+							{
+								$html[] = '<span class="label label-important">' . JText::_('JLIB_RULES_NOT_ALLOWED') . '</span>';
+							}
+							else
+							{
+								$html[] = '<span class="label"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_NOT_ALLOWED_LOCKED')
+									. '</span>';
+							}
+						}
+					}
+					elseif (!empty($component))
+					{
+						$html[] = '<span class="label label-success"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
+							. '</span>';
+					}
+					else
+					{
+						// Special handling for  groups that have global admin because they can't  be denied.
+						// The admin rights can be changed.
+						if ($action->name === 'core.admin')
+						{
+							$html[] = '<span class="label label-success">' . JText::_('JLIB_RULES_ALLOWED') . '</span>';
+						}
+						elseif ($inheritedRule === false)
+						{
+							// Other actions cannot be changed.
+							$html[] = '<span class="label label-important"><i class="icon-lock icon-white"></i> '
+								. JText::_('JLIB_RULES_NOT_ALLOWED_ADMIN_CONFLICT') . '</span>';
+						}
+						else
+						{
+							$html[] = '<span class="label label-success"><i class="icon-lock icon-white"></i> ' . JText::_('JLIB_RULES_ALLOWED_ADMIN')
+								. '</span>';
+						}
+					}
+
+					$html[] = '</td>';
+				}
+
+				$html[] = '</tr>';
+			}
+
+			$html[] = '</tbody>';
+			$html[] = '</table></div>';
+		}
+
+		$html[] = '</div></div>';
+
+		$html[] = '<div class="alert">';
+
+		if ($section == 'component' || $section == null)
+		{
+			$html[] = JText::_('JLIB_RULES_SETTING_NOTES');
+		}
+		else
+		{
+			$html[] = JText::_('JLIB_RULES_SETTING_NOTES_ITEM');
+		}
+
+		$html[] = '</div>';
+
+		return implode("\n", $html);
+	}
 }

--- a/fof/Form/Field/SessionHandler.php
+++ b/fof/Form/Field/SessionHandler.php
@@ -98,7 +98,7 @@ class SessionHandler extends \JFormFieldSessionHandler implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class SessionHandler extends \JFormFieldSessionHandler implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Sql.php
+++ b/fof/Form/Field/Sql.php
@@ -98,7 +98,7 @@ class Sql extends \JFormFieldSql implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
@@ -115,7 +115,7 @@ class Sql extends \JFormFieldSql implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Tel.php
+++ b/fof/Form/Field/Tel.php
@@ -99,7 +99,7 @@ class Tel extends \JFormFieldTel implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class  = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class  = $this->class ? ' class="' . $this->class . '"' : '';
 		$dolink = $this->element['show_link'] == 'true';
 		$empty_replacement = '';
 
@@ -144,9 +144,9 @@ class Tel extends \JFormFieldTel implements FieldInterface
 		$link_url = 'tel:' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
 		// Get field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = ' ' . (string) $this->element['class'];
+			$class = ' ' . $this->class;
 		}
 
 		if ($this->element['show_link'] == 'true')

--- a/fof/Form/Field/Text.php
+++ b/fof/Form/Field/Text.php
@@ -99,7 +99,7 @@ class Text extends \JFormFieldText implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 		$empty_replacement = '';
 
 		if ($this->element['empty_replacement'])
@@ -137,9 +137,9 @@ class Text extends \JFormFieldText implements FieldInterface
 		$empty_replacement		= '';
 
 		// Get field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = (string) $this->element['class'];
+			$class = $this->class;
 		}
 
 		if ($this->element['format'])

--- a/fof/Form/Field/TextArea.php
+++ b/fof/Form/Field/TextArea.php
@@ -98,7 +98,7 @@ class TextArea extends \JFormFieldTextarea implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<div id="' . $this->id . '" ' . $class . '>' .
 			htmlspecialchars(nl2br($this->value), ENT_COMPAT, 'UTF-8') .

--- a/fof/Form/Field/Timezone.php
+++ b/fof/Form/Field/Timezone.php
@@ -98,7 +98,7 @@ class Timezone extends \JFormFieldTimezone implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? (string) $this->class : '';
 
 		$selected = GroupedList::getOptionName($this->getGroups(), $this->value);
 

--- a/fof/Form/Field/Url.php
+++ b/fof/Form/Field/Url.php
@@ -99,7 +99,7 @@ class Url extends \JFormFieldUrl implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class  = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class  = $this->class ? ' class="' . $this->class . '"' : '';
 		$dolink = $this->element['show_link'] == 'true';
 		$empty_replacement = '';
 
@@ -144,9 +144,9 @@ class Url extends \JFormFieldUrl implements FieldInterface
 		$link_url = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
 		// Get field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class .= ' ' . (string) $this->element['class'];
+			$class .= ' ' . $this->class;
 		}
 
 		if ($this->element['show_link'] == 'true')

--- a/fof/Form/Field/User.php
+++ b/fof/Form/Field/User.php
@@ -106,9 +106,9 @@ class User extends \JFormFieldUser implements FieldInterface
 		$class         = '';
 
 		// Get the field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = ' class="' . (string) $this->element['class'] . '"';
+			$class = ' class="' . $this->class . '"';
 		}
 
 		if ($this->element['show_username'] == 'false')
@@ -188,9 +188,9 @@ class User extends \JFormFieldUser implements FieldInterface
 		$user = $this->form->getContainer()->platform->getUser($this->value);
 
 		// Get the field parameters
-		if ($this->element['class'])
+		if ($this->class)
 		{
-			$class = ' class="' . (string) $this->element['class'] . '"';
+			$class = ' class="' . $this->class . '"';
 		}
 
 		if ($this->element['show_username'] == 'false')

--- a/fof/Form/Field/UserGroup.php
+++ b/fof/Form/Field/UserGroup.php
@@ -100,7 +100,7 @@ class UserGroup extends \JFormFieldUsergroup implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		$params = $this->getOptions();
 
@@ -144,7 +144,7 @@ class UserGroup extends \JFormFieldUsergroup implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
+		$class = $this->class ? $this->class : '';
 
 		$db = $this->form->getContainer()->platform->getDbo();
 		$query = $db->getQuery(true);


### PR DESCRIPTION
Hi Nicholas, there the FOF3 modification for #422

I changed only the element defined on the base setup() of J! (so mainly `class`). Some J! fields add more variables, I'll check one by one later (I think I will also standardize all the Fields).

I also removed J! 2.5 code.