### PR TITLE
Reworkfields

### DIFF
--- a/fof/Form/Field/AccessLevel.php
+++ b/fof/Form/Field/AccessLevel.php
@@ -100,38 +100,16 @@ class AccessLevel extends \JFormFieldAccessLevel implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
-
-		$params = $this->getOptions();
-
-		$db    = $this->form->getContainer()->platform->getDbo();
-		$query = $db->getQuery(true);
-
-		$query->select('a.id AS value, a.title AS text');
-		$query->from('#__viewlevels AS a');
-		$query->group('a.id, a.title, a.ordering');
-		$query->order('a.ordering ASC');
-		$query->order($query->qn('title') . ' ASC');
-
-		// Get the options.
-		$db->setQuery($query);
-		$options = $db->loadObjectList();
-
-		// If params is an array, push these options to the array
-		if (is_array($params))
+		if (isset($this->element['legacy']))
 		{
-			$options = array_merge($params, $options);
+			return $this->getInput();
 		}
 
-		// If all levels is allowed, push it into the array.
-		elseif ($params)
-		{
-			array_unshift($options, JHtml::_('select.option', '', JText::_('JOPTION_ACCESS_SHOW_ALL_LEVELS')));
-		}
+		$options = array(
+			'id' => $this->id
+		);
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($options, $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -144,22 +122,42 @@ class AccessLevel extends \JFormFieldAccessLevel implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? (string) $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
 
 		$params = $this->getOptions();
 
 		$db    = $this->form->getContainer()->platform->getDbo();
-		$query = $db->getQuery(true);
-
-		$query->select('a.id AS value, a.title AS text');
-		$query->from('#__viewlevels AS a');
-		$query->group('a.id, a.title, a.ordering');
-		$query->order('a.ordering ASC');
-		$query->order($query->qn('title') . ' ASC');
+		$query = $db->getQuery(true)
+				->select('a.id AS value, a.title AS text')
+				->from('#__viewlevels AS a')
+				->group('a.id, a.title, a.ordering')
+				->order('a.ordering ASC')
+				->order($query->qn('title') . ' ASC');
 
 		// Get the options.
-		$db->setQuery($query);
-		$options = $db->loadObjectList();
+		$options = $db->setQuery($query)->loadObjectList();
 
 		// If params is an array, push these options to the array
 		if (is_array($params))
@@ -173,7 +171,7 @@ class AccessLevel extends \JFormFieldAccessLevel implements FieldInterface
 			array_unshift($options, JHtml::_('select.option', '', JText::_('JOPTION_ACCESS_SHOW_ALL_LEVELS')));
 		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		return '<span ' . ($id ? $id : '') . 'class="'. $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($options, $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Button.php
+++ b/fof/Form/Field/Button.php
@@ -120,19 +120,14 @@ class Button extends Text implements FieldInterface
 		else
 			$type = 'button';
 
-		$text    = $this->element['text'];
+		$text    = $this->element['text'] ? (string) $this->element['text'] : '';
 		$class   = $this->class ? $this->class : '';
-		$icon    = $this->element['icon'] ? (string) $this->element['icon'] : '';
+		$icon    = $this->element['icon'] ? '<span class="icon ' . (string) $this->element['icon'] . '"></span>' : '';
 		$onclick = $this->onclick ? 'onclick="' . $this->onclick . '"' : '';
 		$url     = $this->element['url'] ? 'href="' . $this->parseFieldTags((string) $this->element['url']) . '"' : '';
 		$title   = $this->element['title'] ? 'title="' . JText::_((string) $this->element['title']) . '"' : '';
 
 		$this->value = JText::_($text);
-
-		if ($icon)
-		{
-			$icon = '<span class="icon ' . $icon . '"></span>';
-		}
 
 		return '<' . $type . ' id="' . $this->id . '" class="btn ' . $class . '" ' .
 			$onclick . $url . $title . '>' .

--- a/fof/Form/Field/CacheHandler.php
+++ b/fof/Form/Field/CacheHandler.php
@@ -98,11 +98,16 @@ class CacheHandler extends \JFormFieldCacheHandler implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,9 +120,31 @@ class CacheHandler extends \JFormFieldCacheHandler implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="'. $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Calendar.php
+++ b/fof/Form/Field/Calendar.php
@@ -129,7 +129,7 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 	protected function getCalendar($display)
 	{
 		// Initialize some field attributes.
-		$format  = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
+		$format  = $this->format ? $this->format : '%Y-%m-%d';
 		$class   = $this->class ? $this->class : '';
 		$default = $this->element['default'] ? (string) $this->element['default'] : '';
 
@@ -154,7 +154,7 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 			$date   = $this->form->getContainer()->platform->getDate($this->value, 'UTC');
 
 			// If a known filter is given use it.
-			switch (strtoupper((string) $this->element['filter']))
+			switch (strtoupper($this->filter))
 			{
 				case 'SERVER_UTC':
 					// Convert a date to UTC based on the server timezone.
@@ -192,9 +192,9 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 				$attributes['size'] = $this->size;
 			}
 
-			if ($this->element['maxlength'])
+			if ($this->maxlength)
 			{
-				$attributes['maxlength'] = (int) $this->element['maxlength'];
+				$attributes['maxlength'] = $this->maxlength;
 			}
 
 			if ($this->class)

--- a/fof/Form/Field/Checkbox.php
+++ b/fof/Form/Field/Checkbox.php
@@ -98,25 +98,16 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class    = $this->class ? ' class="' . $this->class . '"' : '';
-		$value    = $this->element['value'] ? (string) $this->element['value'] : '1';
-		$disabled = $this->disabled ? ' disabled="disabled"' : '';
-		$onclick  = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
-		$required = $this->required ? ' required="required" aria-required="true"' : '';
-
-		if (empty($this->value))
+		if (isset($this->element['legacy']))
 		{
-			$checked = (isset($this->checked)) ? ' checked="checked"' : '';
-		}
-		else
-		{
-			$checked = ' checked="checked"';
+			return $this->getInput();
 		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			'<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $required . ' />' .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -129,24 +120,43 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class    = $this->class ? $this->class : '';
-		$value    = $this->element['value'] ? (string) $this->element['value'] : '1';
-		$disabled = $this->disabled ? ' disabled="disabled"' : '';
-		$onclick  = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
-		$required = $this->required ? ' required="required" aria-required="true"' : '';
-
-		if (empty($this->value))
+		if (isset($this->element['legacy']))
 		{
-			$checked = (isset($this->checked)) ? ' checked="checked"' : '';
-		}
-		else
-		{
-			$checked = ' checked="checked"';
+			return $this->getInput();
 		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
-			'<input type="checkbox" name="' . $this->name . '" class="' . $this->id . ' ' . $class . '"' . ' value="'
-			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $disabled . $onclick . $required . ' />' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		$value     = $this->element['value'] ? (string) $this->element['value'] : '1';
+		$disabled  = $this->disabled ? ' disabled="disabled"' : '';
+		$required  = $this->required ? ' required="required" aria-required="true"' : '';
+		$autofocus = $this->autofocus ? ' autofocus' : '';
+		$checked   = $this->checked || !empty($this->value) ? ' checked' : '';
+
+		$onchange  = $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
+		$onclick   = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
+			'<input type="checkbox" name="' . $this->name . '" ' . ($id ? $id : '') . 'class="' . $this->id . ' ' . $class . '"' . ' value="'
+			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $disabled . $onclick . $onchange
+			. $required . $autofocus . ' />' .
 			'</span>';
 	}
 }

--- a/fof/Form/Field/Checkbox.php
+++ b/fof/Form/Field/Checkbox.php
@@ -106,7 +106,7 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 
 		if (empty($this->value))
 		{
-			$checked = (isset($this->element['checked'])) ? ' checked="checked"' : '';
+			$checked = (isset($this->checked)) ? ' checked="checked"' : '';
 		}
 		else
 		{
@@ -137,7 +137,7 @@ class Checkbox extends \JFormFieldCheckbox implements FieldInterface
 
 		if (empty($this->value))
 		{
-			$checked = (isset($this->element['checked'])) ? ' checked="checked"' : '';
+			$checked = (isset($this->checked)) ? ' checked="checked"' : '';
 		}
 		else
 		{

--- a/fof/Form/Field/Checkboxes.php
+++ b/fof/Form/Field/Checkboxes.php
@@ -99,7 +99,16 @@ class Checkboxes extends \JFormFieldCheckboxes implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		return $this->getRepeatable();
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -112,10 +121,33 @@ class Checkboxes extends \JFormFieldCheckboxes implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class     = $this->class ? (string) $this->class : $this->id;
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
 		$translate = $this->element['translate'] ? (string) $this->element['translate'] : false;
 
-		$html = '<span class="' . $class . '">';
+		$html = '<span ' . ($id ? $id : '') . 'class="' . $class . '">';
 
 		foreach ($this->value as $value) {
 

--- a/fof/Form/Field/Components.php
+++ b/fof/Form/Field/Components.php
@@ -106,11 +106,11 @@ class Components extends \JFormFieldList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		$options = array(
+			'id' => $this->id
+		);
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -123,9 +123,26 @@ class Components extends \JFormFieldList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? (string) $this->class : '';
+		$options = array(
+			'class' => $this->id
+		);
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}
@@ -176,8 +193,7 @@ class Components extends \JFormFieldList implements FieldInterface
 			->from($db->qn('#__extensions'))
 			->where($db->qn('type') . ' = ' . $db->q('component'))
 			->where($db->qn('client_id') . ' IN (' . implode(',', $client_ids) . ')');
-		$db->setQuery($query);
-		$components = $db->loadObjectList('element');
+		$components = $db->setQuery($query)->loadObjectList('element');
 
 		// Convert to array of objects, so we can use sortObjects()
 		// Also translate component names with JText::_()

--- a/fof/Form/Field/Editor.php
+++ b/fof/Form/Field/Editor.php
@@ -98,9 +98,16 @@ class Editor extends \JFormFieldEditor implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<div id="' . $this->id . '" ' . $class . '>' . $this->value . '</div>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -113,8 +120,30 @@ class Editor extends \JFormFieldEditor implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<div class="' . $this->id . ' ' . $class . '">' . $this->value . '</div>';
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<div ' . ($id ? $id : '') . 'class="' . $class . '">' . $this->value . '</div>';
 	}
 }

--- a/fof/Form/Field/Email.php
+++ b/fof/Form/Field/Email.php
@@ -99,31 +99,16 @@ class Email extends \JFormFieldEMail implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
-		$dolink = $this->element['show_link'] == 'true';
-		$empty_replacement = '';
-
-		if ($this->element['empty_replacement'])
+		if (isset($this->element['legacy']))
 		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
+			return $this->getInput();
 		}
 
-		if (!empty($empty_replacement) && empty($this->value))
-		{
-			$this->value = JText::_($empty_replacement);
-		}
+		$options = array(
+			'id' => $this->id
+		);
 
-		$innerHtml = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		if ($dolink)
-		{
-			$innerHtml = '<a href="mailto:' . $innerHtml . '">' .
-				$innerHtml . '</a>';
-		}
-
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			$innerHtml .
-			'</span>';
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -136,37 +121,33 @@ class Email extends \JFormFieldEMail implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		// Initialise
-		$class = '';
-		$show_link = false;
-		$empty_replacement = '';
-
-		// Get field parameters
-		if ($this->class)
+		if (isset($this->element['legacy']))
 		{
-			$class = $this->class;
+			return $this->getInput();
 		}
 
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
+		$options = array(
+			'class' => $this->id
+		);
 
-		if ($this->element['url'])
-		{
-			$link_url = $this->element['url'];
-		}
-		else
-		{
-			$link_url = 'mailto:' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-		}
+		return $this->getFieldContents($options);
+	}
 
-		if ($this->element['empty_replacement'])
-		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
-		}
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
 
-		// Get the (optionally formatted) value
+		$show_link         = in_array((string) $this->element['show_link'], array('true', '1', 'on', 'yes'));
+		$empty_replacement = $this->element['empty_replacement'] ? (string) $this->element['empty_replacement'] : '';
+
 		if (!empty($empty_replacement) && empty($this->value))
 		{
 			$this->value = JText::_($empty_replacement);
@@ -174,23 +155,63 @@ class Email extends \JFormFieldEMail implements FieldInterface
 
 		$value = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
-		// Create the HTML
-		$html = '<span class="' . $this->id . ' ' . $class . '">';
-
 		if ($show_link)
 		{
-			$html .= '<a href="' . $link_url . '">';
+			if ($this->element['url'])
+			{
+				$link_url = $this->parseFieldTags((string) $this->element['url']);
+			}
+			else
+			{
+				$link_url = $value;
+			}
+
+			$html = '<a href="mailto:' . $link_url . '">' .
+				$value . '</a>';
 		}
 
-		$html .= $value;
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '"">' .
+			$html .
+			'</span>';
+	}
 
-		if ($show_link)
+	/**
+	 * Replace string with tags that reference fields
+	 *
+	 * @param   string  $text  Text to process
+	 *
+	 * @return  string         Text with tags replace
+	 */
+	protected function parseFieldTags($text)
+	{
+		$ret = $text;
+
+		// Replace [ITEM:ID] in the URL with the item's key value (usually:
+		// the auto-incrementing numeric ID)
+		$keyfield = $this->item->getKeyName();
+		$replace  = $this->item->$keyfield;
+		$ret = str_replace('[ITEM:ID]', $replace, $ret);
+
+		// Replace the [ITEMID] in the URL with the current Itemid parameter
+		$ret = str_replace('[ITEMID]', $this->form->getContainer()->input->getInt('Itemid', 0), $ret);
+
+		// Replace other field variables in the URL
+		$fields = $this->item->getTableFields();
+
+		foreach ($fields as $fielddata)
 		{
-			$html .= '</a>';
+			$fieldname = $fielddata->Field;
+
+			if (empty($fieldname))
+			{
+				$fieldname = $fielddata->column_name;
+			}
+
+			$search    = '[ITEM:' . strtoupper($fieldname) . ']';
+			$replace   = $this->item->$fieldname;
+			$ret  = str_replace($search, $replace, $ret);
 		}
 
-		$html .= '</span>';
-
-		return $html;
+		return $ret;
 	}
 }

--- a/fof/Form/Field/GenericList.php
+++ b/fof/Form/Field/GenericList.php
@@ -100,6 +100,11 @@ class GenericList extends \JFormFieldList implements FieldInterface
 	 */
 	public function getStatic()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
@@ -117,44 +122,32 @@ class GenericList extends \JFormFieldList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$show_link         = false;
-		$link_url          = '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
 		$class = $this->class ? $this->class : '';
 
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
-
-		if ($this->element['url'])
-		{
-			$link_url = $this->element['url'];
-		}
-		else
-		{
-			$show_link = false;
-		}
-
-		if ($show_link && ($this->item instanceof DataModel))
+		if ($this->element['url'] && ($this->item instanceof DataModel))
 		{
 			$link_url = $this->parseFieldTags($link_url);
 		}
 		else
 		{
-			$show_link = false;
+			$link_url = false;
 		}
 
 		$html = '<span class="' . $this->id . ' ' . $class . '">';
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '<a href="' . $link_url . '">';
 		}
 
 		$html .= htmlspecialchars(self::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8');
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '</a>';
 		}
@@ -312,7 +305,7 @@ class GenericList extends \JFormFieldList implements FieldInterface
 		$source_value     = empty($this->element['source_value']) ? '*' : (string) $this->element['source_value'];
 		$source_translate = empty($this->element['source_translate']) ? 'true' : (string) $this->element['source_translate'];
 		$source_translate = in_array(strtolower($source_translate), array('true','yes','1','on')) ? true : false;
-		$source_format	  = empty($this->element['source_format']) ? '' : (string) $this->element['source_format'];
+		$source_format    = empty($this->element['source_format']) ? '' : (string) $this->element['source_format'];
 
 		if ($source_class && $source_method)
 		{

--- a/fof/Form/Field/GroupedList.php
+++ b/fof/Form/Field/GroupedList.php
@@ -99,24 +99,16 @@ class GroupedList extends \JFormFieldGroupedList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? $this->class : '';
-
-		$selected = self::getOptionName($this->getGroups(), $this->value);
-
-		if (is_null($selected))
+		if (isset($this->element['legacy']))
 		{
-			$selected = array(
-				'group'	 => '',
-				'item'	 => ''
-			);
+			return $this->getInput();
 		}
 
-		return '<span id="' . $this->id . '-group" class="fof-groupedlist-group ' . $class . '>' .
-			htmlspecialchars($selected['group'], ENT_COMPAT, 'UTF-8') .
-			'</span>' .
-			'<span id="' . $this->id . '-item" class="fof-groupedlist-item ' . $class . '>' .
-			htmlspecialchars($selected['item'], ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -129,7 +121,29 @@ class GroupedList extends \JFormFieldGroupedList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? $fieldOptions['id'] : null;
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
 
 		$selected = self::getOptionName($this->getGroups(), $this->value);
 
@@ -141,10 +155,10 @@ class GroupedList extends \JFormFieldGroupedList implements FieldInterface
 			);
 		}
 
-		return '<span class="' . $this->id . '-group fof-groupedlist-group ' . $class . '">' .
+		return '<span ' . ($id ? 'id="' . $id . '-group" ' : '') . 'class="fof-groupedlist-group ' . $class . '>' .
 			htmlspecialchars($selected['group'], ENT_COMPAT, 'UTF-8') .
 			'</span>' .
-			'<span class="' . $this->id . '-item fof-groupedlist-item ' . $class . '">' .
+			'<span ' . ($id ? 'id="' . $id . '-item" ' : '') . 'class="fof-groupedlist-item ' . $class . '>' .
 			htmlspecialchars($selected['item'], ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/ImageList.php
+++ b/fof/Form/Field/ImageList.php
@@ -100,13 +100,59 @@ class ImageList extends \JFormFieldImageList implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$imgattr = array(
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
 			'id' => $this->id
 		);
 
-		if ($this->class)
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		if (isset($this->element['legacy']))
 		{
-			$imgattr['class'] = $this->class;
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$imgattr = array();
+
+		if ($fieldOptions['id'])
+		{
+			$imgattr['id'] = $fieldOptions['id'];
+		}
+
+		if ($this->class || $fieldOptions['class'])
+		{
+			$imgattr['class'] = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
 		}
 
 		if ($this->element['style'])
@@ -161,18 +207,5 @@ class ImageList extends \JFormFieldImageList implements FieldInterface
 		}
 
 		return JHtml::image($src, $alt, $imgattr);
-	}
-
-	/**
-	 * Get the rendering of this field type for a repeatable (grid) display,
-	 * e.g. in a view listing many item (typically a "browse" task)
-	 *
-	 * @since 2.0
-	 *
-	 * @return  string  The field HTML
-	 */
-	public function getRepeatable()
-	{
-		return $this->getStatic();
 	}
 }

--- a/fof/Form/Field/Integer.php
+++ b/fof/Form/Field/Integer.php
@@ -98,6 +98,11 @@ class Integer extends \JFormFieldInteger implements FieldInterface
 	 */
 	public function getStatic()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		return '<span id="' . $this->id . '" ' . $class . '>' .
@@ -115,6 +120,11 @@ class Integer extends \JFormFieldInteger implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		$class = $this->class ? $this->class : '';
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .

--- a/fof/Form/Field/Language.php
+++ b/fof/Form/Field/Language.php
@@ -121,11 +121,16 @@ class Language extends \JFormFieldLanguage implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -138,9 +143,31 @@ class Language extends \JFormFieldLanguage implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Media.php
+++ b/fof/Form/Field/Media.php
@@ -100,13 +100,59 @@ class Media extends \JFormFieldMedia implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$imgattr = array(
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
 			'id' => $this->id
 		);
 
-		if ($this->class)
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		if (isset($this->element['legacy']))
 		{
-			$imgattr['class'] = $this->class;
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$imgattr = array();
+
+		if ($fieldOptions['id'])
+		{
+			$imgattr['id'] = $fieldOptions['id'];
+		}
+
+		if ($this->class || $fieldOptions['class'])
+		{
+			$imgattr['class'] = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
 		}
 
 		if ($this->element['style'])
@@ -158,18 +204,5 @@ class Media extends \JFormFieldMedia implements FieldInterface
 		}
 
 		return JHtml::image($src, $alt, $imgattr);
-	}
-
-	/**
-	 * Get the rendering of this field type for a repeatable (grid) display,
-	 * e.g. in a view listing many item (typically a "browse" task)
-	 *
-	 * @since 2.0
-	 *
-	 * @return  string  The field HTML
-	 */
-	public function getRepeatable()
-	{
-		return $this->getStatic();
 	}
 }

--- a/fof/Form/Field/Model.php
+++ b/fof/Form/Field/Model.php
@@ -118,44 +118,19 @@ class Model extends GenericList implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class				= $this->id;
-		$format_string		= '';
-		$show_link			= false;
-		$link_url			= '';
-		$empty_replacement	= '';
-
 		// Get field parameters
-		if ($this->class)
-		{
-			$class = $this->class;
-		}
+		$class					= $this->class ? $this->class : $this->id;
+		$format_string			= $this->element['format'] ? (string) $this->element['format'] : '';
+		$link_url				= $this->element['url'] ? (string) $this->element['url'] : '';
+		$empty_replacement		= $this->element['empty_replacement'] ? : (string) $this->element['empty_replacement'] : '';
 
-		if ($this->element['format'])
-		{
-			$format_string = (string) $this->element['format'];
-		}
-
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
-
-		if ($this->element['url'])
-		{
-			$link_url = $this->element['url'];
-		}
-		else
-		{
-			$show_link = false;
-		}
-
-		if ($show_link && ($this->item instanceof DataModel))
+		if ($link_url && ($this->item instanceof DataModel))
 		{
 			$link_url = $this->parseFieldTags($link_url);
 		}
 		else
 		{
-			$show_link = false;
+			$link_url = false;
 		}
 
 		if ($this->element['empty_replacement'])
@@ -183,14 +158,14 @@ class Model extends GenericList implements FieldInterface
 		// Create the HTML
 		$html = '<span class="' . $class . '">';
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '<a href="' . $link_url . '">';
 		}
 
 		$html .= $value;
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '</a>';
 		}

--- a/fof/Form/Field/Password.php
+++ b/fof/Form/Field/Password.php
@@ -98,11 +98,16 @@ class Password extends \JFormFieldPassword implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,6 +120,32 @@ class Password extends \JFormFieldPassword implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		return $this->getStatic();
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
+			htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') .
+			'</span>';
 	}
 }

--- a/fof/Form/Field/Plugins.php
+++ b/fof/Form/Field/Plugins.php
@@ -98,11 +98,16 @@ class Plugins extends \JFormFieldPlugins implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,9 +120,31 @@ class Plugins extends \JFormFieldPlugins implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Published.php
+++ b/fof/Form/Field/Published.php
@@ -211,33 +211,11 @@ class Published extends \JFormFieldList implements FieldInterface
 			throw new DataModelRequired(__CLASS__);
 		}
 
-		// Initialise
-		$prefix = '';
-		$checkbox = 'cb';
-		$publish_up = null;
-		$publish_down = null;
-		$enabled = true;
-
-		// Get options
-		if ($this->element['prefix'])
-		{
-			$prefix = (string) $this->element['prefix'];
-		}
-
-		if ($this->element['checkbox'])
-		{
-			$checkbox = (string) $this->element['checkbox'];
-		}
-
-		if ($this->element['publish_up'])
-		{
-			$publish_up = (string) $this->element['publish_up'];
-		}
-
-		if ($this->element['publish_down'])
-		{
-			$publish_down = (string) $this->element['publish_down'];
-		}
+		$prefix       = $this->element['prefix'] ? (string) $this->element['prefix'] : '';
+		$checkbox     = $this->element['checkbox'] ? (string) $this->element['checkbox'] : 'cb';
+		$publish_up   = $this->element['publish_up'] ? (string) $this->element['publish_up'] : null;
+		$publish_down = $this->element['publish_down'] ? (string) $this->element['publish_down'] : null;
+		$enabled      = true;
 
 		// @todo Enforce ACL checks to determine if the field should be enabled or not
 		// Get the HTML

--- a/fof/Form/Field/Radio.php
+++ b/fof/Form/Field/Radio.php
@@ -98,11 +98,16 @@ class Radio extends \JFormFieldRadio implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,9 +120,31 @@ class Radio extends \JFormFieldRadio implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/SessionHandler.php
+++ b/fof/Form/Field/SessionHandler.php
@@ -98,11 +98,16 @@ class SessionHandler extends \JFormFieldSessionHandler implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,9 +120,32 @@ class SessionHandler extends \JFormFieldSessionHandler implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Sql.php
+++ b/fof/Form/Field/Sql.php
@@ -98,11 +98,16 @@ class Sql extends \JFormFieldSql implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,9 +120,31 @@ class Sql extends \JFormFieldSql implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		$class = $this->class ? $this->class : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<span class="' . $this->id . ' ' . $class . '">' .
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($this->getOptions(), $this->value), ENT_COMPAT, 'UTF-8') .
 			'</span>';
 	}

--- a/fof/Form/Field/Tel.php
+++ b/fof/Form/Field/Tel.php
@@ -99,31 +99,16 @@ class Tel extends \JFormFieldTel implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class  = $this->class ? ' class="' . $this->class . '"' : '';
-		$dolink = $this->element['show_link'] == 'true';
-		$empty_replacement = '';
-
-		if ($this->element['empty_replacement'])
+		if (isset($this->element['legacy']))
 		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
+			return $this->getInput();
 		}
 
-		if (!empty($empty_replacement) && empty($this->value))
-		{
-			$this->value = JText::_($empty_replacement);
-		}
+		$options = array(
+			'id' => $this->id
+		);
 
-		$innerHtml = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		if ($dolink)
-		{
-			$innerHtml = '<a href="tel:' . $innerHtml . '">' .
-				$innerHtml . '</a>';
-		}
-
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			$innerHtml .
-			'</span>';
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -136,30 +121,33 @@ class Tel extends \JFormFieldTel implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		// Initialise
-		$class             = $this->id;
-		$show_link         = false;
-		$empty_replacement = '';
-
-		$link_url = 'tel:' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		// Get field parameters
-		if ($this->class)
+		if (isset($this->element['legacy']))
 		{
-			$class = ' ' . $this->class;
+			return $this->getInput();
 		}
 
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
+		$options = array(
+			'class' => $this->id
+		);
 
-		if ($this->element['empty_replacement'])
-		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
-		}
+		return $this->getFieldContents($options);
+	}
 
-		// Get the (optionally formatted) value
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		$show_link         = in_array((string) $this->element['show_link'], array('true', '1', 'on', 'yes'));
+		$empty_replacement = $this->element['empty_replacement'] ? (string) $this->element['empty_replacement'] : '';
+
 		if (!empty($empty_replacement) && empty($this->value))
 		{
 			$this->value = JText::_($empty_replacement);
@@ -167,23 +155,63 @@ class Tel extends \JFormFieldTel implements FieldInterface
 
 		$value = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
-		// Create the HTML
-		$html = '<span class="' . $class . '">';
-
 		if ($show_link)
 		{
-			$html .= '<a href="' . $link_url . '">';
+			if ($this->element['url'])
+			{
+				$link_url = $this->parseFieldTags((string) $this->element['url']);
+			}
+			else
+			{
+				$link_url = $value;
+			}
+
+			$html = '<a href="tel:' . $link_url . '">' .
+				$value . '</a>';
 		}
 
-		$html .= $value;
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '"">' .
+			$html .
+			'</span>';
+	}
 
-		if ($show_link)
+	/**
+	 * Replace string with tags that reference fields
+	 *
+	 * @param   string  $text  Text to process
+	 *
+	 * @return  string         Text with tags replace
+	 */
+	protected function parseFieldTags($text)
+	{
+		$ret = $text;
+
+		// Replace [ITEM:ID] in the URL with the item's key value (usually:
+		// the auto-incrementing numeric ID)
+		$keyfield = $this->item->getKeyName();
+		$replace  = $this->item->$keyfield;
+		$ret = str_replace('[ITEM:ID]', $replace, $ret);
+
+		// Replace the [ITEMID] in the URL with the current Itemid parameter
+		$ret = str_replace('[ITEMID]', $this->form->getContainer()->input->getInt('Itemid', 0), $ret);
+
+		// Replace other field variables in the URL
+		$fields = $this->item->getTableFields();
+
+		foreach ($fields as $fielddata)
 		{
-			$html .= '</a>';
+			$fieldname = $fielddata->Field;
+
+			if (empty($fieldname))
+			{
+				$fieldname = $fielddata->column_name;
+			}
+
+			$search    = '[ITEM:' . strtoupper($fieldname) . ']';
+			$replace   = $this->item->$fieldname;
+			$ret  = str_replace($search, $replace, $ret);
 		}
 
-		$html .= '</span>';
-
-		return $html;
+		return $ret;
 	}
 }

--- a/fof/Form/Field/Text.php
+++ b/fof/Form/Field/Text.php
@@ -99,13 +99,14 @@ class Text extends \JFormFieldText implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
-		$empty_replacement = '';
-
-		if ($this->element['empty_replacement'])
+		if (isset($this->element['legacy']))
 		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
+			return $this->getInput();
 		}
+
+		$class = $this->class ? ' class="' . $this->class . '"' : '';
+
+		$empty_replacement = $this->element['empty_replacement'] ? (string) $this->element['empty_replacement'] : '';
 
 		if (!empty($empty_replacement) && empty($this->value))
 		{
@@ -127,62 +128,27 @@ class Text extends \JFormFieldText implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		// Initialise
-		$class					= $this->id;
-		$format_string			= '';
-		$format_if_not_empty	= false;
-		$parse_value			= false;
-		$show_link				= false;
-		$link_url				= '';
-		$empty_replacement		= '';
+		$class					= $this->class ? $this->class : $this->id;
+		$format_string			= $this->element['format'] ? (string) $this->element['format'] : '';
+		$format_if_not_empty	= in_array((string) $this->element['format_if_not_empty']), array('true', '1', 'on', 'yes');
+		$parse_value			= in_array((string) $this->element['parse_value']), array('true', '1', 'on', 'yes');
+		$link_url				= $this->element['url'] ? (string) $this->element['url'] : '';
+		$empty_replacement		= $this->element['empty_replacement'] ? : (string) $this->element['empty_replacement'] : '';
 
-		// Get field parameters
-		if ($this->class)
-		{
-			$class = $this->class;
-		}
 
-		if ($this->element['format'])
-		{
-			$format_string = (string) $this->element['format'];
-		}
-
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
-
-		if ($this->element['format_if_not_empty'] == 'true')
-		{
-			$format_if_not_empty = true;
-		}
-
-		if ($this->element['parse_value'] == 'true')
-		{
-			$parse_value = true;
-		}
-
-		if ($this->element['url'])
-		{
-			$link_url = $this->element['url'];
-		}
-		else
-		{
-			$show_link = false;
-		}
-
-		if ($show_link && ($this->item instanceof DataModel))
+		if ($link_url && ($this->item instanceof DataModel))
 		{
 			$link_url = $this->parseFieldTags($link_url);
 		}
 		else
 		{
-			$show_link = false;
-		}
-
-		if ($this->element['empty_replacement'])
-		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
+			$link_url = false;
 		}
 
 		// Get the (optionally formatted) value
@@ -211,14 +177,14 @@ class Text extends \JFormFieldText implements FieldInterface
 		// Create the HTML
 		$html = '<span class="' . $class . '">';
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '<a href="' . $link_url . '">';
 		}
 
 		$html .= $value;
 
-		if ($show_link)
+		if ($link_url)
 		{
 			$html .= '</a>';
 		}

--- a/fof/Form/Field/TextArea.php
+++ b/fof/Form/Field/TextArea.php
@@ -98,11 +98,16 @@ class TextArea extends \JFormFieldTextarea implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? ' class="' . $this->class . '"' : '';
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
 
-		return '<div id="' . $this->id . '" ' . $class . '>' .
-			htmlspecialchars(nl2br($this->value), ENT_COMPAT, 'UTF-8') .
-			'</div>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -115,6 +120,32 @@ class TextArea extends \JFormFieldTextarea implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		return $this->getStatic();
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		return '<div ' . ($id ? $id : '') . 'class="' . $class . '">' .
+			htmlspecialchars(nl2br($this->value), ENT_COMPAT, 'UTF-8') .
+			'</div>';
 	}
 }

--- a/fof/Form/Field/Timezone.php
+++ b/fof/Form/Field/Timezone.php
@@ -98,24 +98,16 @@ class Timezone extends \JFormFieldTimezone implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class = $this->class ? (string) $this->class : '';
-
-		$selected = GroupedList::getOptionName($this->getGroups(), $this->value);
-
-		if (is_null($selected))
+		if (isset($this->element['legacy']))
 		{
-			$selected = array(
-				'group'	 => '',
-				'item'	 => ''
-			);
+			return $this->getInput();
 		}
 
-		return '<span id="' . $this->id . '-group" class="fof-groupedlist-group ' . $class . '>' .
-			htmlspecialchars($selected['group'], ENT_COMPAT, 'UTF-8') .
-			'</span>' .
-			'<span id="' . $this->id . '-item" class="fof-groupedlist-item ' . $class . '>' .
-			htmlspecialchars($selected['item'], ENT_COMPAT, 'UTF-8') .
-			'</span>';
+		$options = array(
+			'id' => $this->id
+		);
+
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -128,6 +120,45 @@ class Timezone extends \JFormFieldTimezone implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		return $this->getStatic();
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
+		$options = array(
+			'class' => $this->id
+		);
+
+		return $this->getFieldContents($options);
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? $fieldOptions['id'] : null;
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		$selected = GroupedList::getOptionName($this->getGroups(), $this->value);
+
+		if (is_null($selected))
+		{
+			$selected = array(
+				'group'	 => '',
+				'item'	 => ''
+			);
+		}
+
+		return '<span ' . ($id ? 'id="' . $id . '-group" ' : '') . 'class="fof-groupedlist-group ' . $class . '>' .
+			htmlspecialchars($selected['group'], ENT_COMPAT, 'UTF-8') .
+			'</span>' .
+			'<span ' . ($id ? 'id="' . $id . '-item" ' : '') . 'class="fof-groupedlist-item ' . $class . '>' .
+			htmlspecialchars($selected['item'], ENT_COMPAT, 'UTF-8') .
+			'</span>';
 	}
 }

--- a/fof/Form/Field/Title.php
+++ b/fof/Form/Field/Title.php
@@ -32,25 +32,9 @@ class Title extends Text implements FieldInterface
 	public function getRepeatable()
 	{
 		// Initialise
-		$slug_field		= 'slug';
-		$slug_format	= '(%s)';
-		$slug_class		= 'small';
-
-		// Get field parameters
-		if ($this->element['slug_field'])
-		{
-			$slug_field = (string) $this->element['slug_field'];
-		}
-
-		if ($this->element['slug_format'])
-		{
-			$slug_format = (string) $this->element['slug_format'];
-		}
-
-		if ($this->element['slug_class'])
-		{
-			$slug_class = (string) $this->element['slug_class'];
-		}
+		$slug_field  = isset($this->element['slug_field']) ? (string) $this->element['slug_field'] : $this->item->getColumnAlias('slug');
+		$slug_format = $this->element['slug_format'] ? (string) $this->element['slug_format'] : '(%s)';
+		$slug_class  = $this->element['slug_class']  ? (string) $this->element['slug_class']  : 'small';
 
 		// Get the regular display
 		$html = parent::getRepeatable();

--- a/fof/Form/Field/Url.php
+++ b/fof/Form/Field/Url.php
@@ -99,31 +99,16 @@ class Url extends \JFormFieldUrl implements FieldInterface
 	 */
 	public function getStatic()
 	{
-		$class  = $this->class ? ' class="' . $this->class . '"' : '';
-		$dolink = $this->element['show_link'] == 'true';
-		$empty_replacement = '';
-
-		if ($this->element['empty_replacement'])
+		if (isset($this->element['legacy']))
 		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
+			return $this->getInput();
 		}
 
-		if (!empty($empty_replacement) && empty($this->value))
-		{
-			$this->value = JText::_($empty_replacement);
-		}
+		$options = array(
+			'id' => $this->id
+		);
 
-		$innerHtml = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		if ($dolink)
-		{
-			$innerHtml = '<a href="' . $innerHtml . '">' .
-				$innerHtml . '</a>';
-		}
-
-		return '<span id="' . $this->id . '" ' . $class . '>' .
-			$innerHtml .
-			'</span>';
+		return $this->getFieldContents($options);
 	}
 
 	/**
@@ -136,54 +121,49 @@ class Url extends \JFormFieldUrl implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
-		// Initialise
-		$class             = $this->id;
-		$show_link         = false;
-		$empty_replacement = '';
-
-		$link_url = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		// Get field parameters
-		if ($this->class)
+		if (isset($this->element['legacy']))
 		{
-			$class .= ' ' . $this->class;
+			return $this->getInput();
 		}
 
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
+		$options = array(
+			'class' => $this->id
+		);
 
-		if ($this->element['empty_replacement'])
-		{
-			$empty_replacement = (string) $this->element['empty_replacement'];
-		}
+		return $this->getFieldContents($options);
+	}
 
-		// Get the (optionally formatted) value
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @param   array   $fieldOptions  Options to be passed into the field
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getFieldContents(array $fieldOptions = array())
+	{
+		$id    = isset($fieldOptions['id']) ? 'id="' . $fieldOptions['id'] . '" ' : '';
+		$class = $this->class . (isset($fieldOptions['class']) ? ' ' . $fieldOptions['class'] : '');
+
+		$show_link = $this->element['show_link'] == 'true';
+
+		$empty_replacement = $this->element['empty_replacement'] ? (string) $this->element['empty_replacement'] : '';
+
 		if (!empty($empty_replacement) && empty($this->value))
 		{
 			$this->value = JText::_($empty_replacement);
 		}
 
-		$value = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
-
-		// Create the HTML
-		$html = '<span class="' . $class . '">';
+		$html = htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
 		if ($show_link)
 		{
-			$html .= '<a href="' . $link_url . '">';
+			$html = '<a href="' . $html . '">' .
+				$html . '</a>';
 		}
 
-		$html .= $value;
-
-		if ($show_link)
-		{
-			$html .= '</a>';
-		}
-
-		$html .= '</span>';
-
-		return $html;
+		return '<span ' . ($id ? $id : '') . 'class="' . $class . '"">' .
+			$html .
+			'</span>';
 	}
 }

--- a/fof/Form/Field/User.php
+++ b/fof/Form/Field/User.php
@@ -98,38 +98,17 @@ class User extends \JFormFieldUser implements FieldInterface
 	 */
 	public function getStatic()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		// Initialise
-		$show_username = true;
-		$show_email    = false;
-		$show_name     = false;
-		$show_id       = false;
-		$class         = '';
-
-		// Get the field parameters
-		if ($this->class)
-		{
-			$class = ' class="' . $this->class . '"';
-		}
-
-		if ($this->element['show_username'] == 'false')
-		{
-			$show_username = false;
-		}
-
-		if ($this->element['show_email'] == 'true')
-		{
-			$show_email = true;
-		}
-
-		if ($this->element['show_name'] == 'true')
-		{
-			$show_name = true;
-		}
-
-		if ($this->element['show_id'] == 'true')
-		{
-			$show_id = true;
-		}
+		$show_username = !$this->element['show_username'] == 'false';
+		$show_email    = $this->element['show_email'] == 'true';
+		$show_name     = $this->element['show_name'] == 'true';
+		$show_id       = $this->element['show_id'] == 'true';
+		$class         = $this->class ? ' class="' . $this->class . '"' : '';
 
 		// Get the user record
 		$user = $this->form->getContainer()->platform->getUser($this->value);
@@ -172,16 +151,21 @@ class User extends \JFormFieldUser implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		// Initialise
-		$show_username = true;
-		$show_email    = true;
-		$show_name     = true;
-		$show_id       = true;
-		$show_avatar   = true;
-		$show_link     = false;
-		$link_url      = null;
+		$show_username = !$this->element['show_username'] == 'false';
+		$show_email    = !$this->element['show_email'] == 'false';
+		$show_name     = !$this->element['show_name'] == 'false';
+		$show_id       = !$this->element['show_id'] == 'false';
+		$show_avatar   = !$this->element['show_avatar'] == 'false';
+		$show_link     = $this->element['show_link'] == 'true';
+		$link_url      = $this->element['link_url'] ? $this->element['link_url'] : null;
 		$avatar_method = 'gravatar';
-		$avatar_size   = 64;
+		$avatar_size   = $this->element['avatar_size'] ? $this->element['avatar_size'] : 64;
 		$class         = '';
 
 		// Get the user record
@@ -193,64 +177,19 @@ class User extends \JFormFieldUser implements FieldInterface
 			$class = ' class="' . $this->class . '"';
 		}
 
-		if ($this->element['show_username'] == 'false')
-		{
-			$show_username = false;
-		}
-
-		if ($this->element['show_email'] == 'false')
-		{
-			$show_email = false;
-		}
-
-		if ($this->element['show_name'] == 'false')
-		{
-			$show_name = false;
-		}
-
-		if ($this->element['show_id'] == 'false')
-		{
-			$show_id = false;
-		}
-
-		if ($this->element['show_avatar'] == 'false')
-		{
-			$show_avatar = false;
-		}
-
 		if ($this->element['avatar_method'])
 		{
 			$avatar_method = strtolower($this->element['avatar_method']);
 		}
 
-		if ($this->element['avatar_size'])
+		if (!$link_url && $this->form->getContainer()->platform->isBackend())
 		{
-			$avatar_size = $this->element['avatar_size'];
-		}
-
-		if ($this->element['show_link'] == 'true')
-		{
-			$show_link = true;
-		}
-
-		if ($this->element['link_url'])
-		{
-			$link_url = $this->element['link_url'];
-		}
+				$link_url = 'index.php?option=com_users&task=user.edit&id=[USER:ID]';
 		else
 		{
-			if ($this->form->getContainer()->platform->isBackend())
-			{
-				// If no link is defined in the back-end, assume the user edit
-				// link in the User Manager component
-				$link_url = 'index.php?option=com_users&task=user.edit&id=[USER:ID]';
-			}
-			else
-			{
-				// If no link is defined in the front-end, we can't create a
-				// default link. Therefore, show no link.
-				$show_link = false;
-			}
+			// If no link is defined in the front-end, we can't create a
+			// default link. Therefore, show no link.
+			$show_link = false;
 		}
 
 		// Post-process the link URL

--- a/fof/Form/Field/UserGroup.php
+++ b/fof/Form/Field/UserGroup.php
@@ -100,22 +100,25 @@ class UserGroup extends \JFormFieldUsergroup implements FieldInterface
 	 */
 	public function getStatic()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		$class = $this->class ? ' class="' . $this->class . '"' : '';
 
 		$params = $this->getOptions();
 
 		$db = $this->form->getContainer()->platform->getDbo();
-		$query = $db->getQuery(true);
-
-		$query->select('a.id AS value, a.title AS text');
-		$query->from('#__usergroups AS a');
-		$query->group('a.id, a.title');
-		$query->order('a.id ASC');
-		$query->order($query->qn('title') . ' ASC');
+		$query = $db->getQuery(true)
+				->select('a.id AS value, a.title AS text')
+				->from('#__usergroups AS a')
+				->group('a.id, a.title')
+				->order('a.id ASC')
+				->order($query->qn('title') . ' ASC');
 
 		// Get the options.
-		$db->setQuery($query);
-		$options = $db->loadObjectList();
+		$options = $db->setQuery($query)->loadObjectList();
 
 		// If params is an array, push these options to the array
 		if (is_array($params))
@@ -144,21 +147,23 @@ class UserGroup extends \JFormFieldUsergroup implements FieldInterface
 	 */
 	public function getRepeatable()
 	{
+		if (isset($this->element['legacy']))
+		{
+			return $this->getInput();
+		}
+
 		$class = $this->class ? $this->class : '';
 
 		$db = $this->form->getContainer()->platform->getDbo();
-		$query = $db->getQuery(true);
-
-		$query->select('a.id AS value, a.title AS text');
-		$query->from('#__usergroups AS a');
-		$query->group('a.id, a.title');
-		$query->order('a.id ASC');
-		$query->order($query->qn('title') . ' ASC');
+		$query = $db->getQuery(true)
+				->select('a.id AS value, a.title AS text')
+				->from('#__usergroups AS a')
+				->group('a.id, a.title')
+				->order('a.id ASC')
+				->order($query->qn('title') . ' ASC');
 
 		// Get the options.
-		$db->setQuery($query);
-		$options = $db->loadObjectList();
-
+		$options = $db->setQuery($query)->loadObjectList();
 
 		return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars(GenericList::getOptionName($options, $this->value), ENT_COMPAT, 'UTF-8') .


### PR DESCRIPTION
#438

- Using `getFieldContents` for all fields where the repeatable and static are alike except `id` and `class`.
- Added new attribute `legacy` for all fields that extends directly a J! field.
- Removed `show_link` from: `Text`, `Model` and `GenericList`. Using `url` instead.
- Checkbox: Added attribute `autofocus` (J! native)
- Email & Tel: Hardcode the mailto: and tel:, using parseFieldTags is `url` attribute is set
- Title: Using `getColumnAlias` instead of hardcoded string for slug (tested on FOF2)
- Tag: Added getRepeatable and getStatic (tested on FOF2)
- Url: Added `url` attribute (same behavior as Email and Tel), using parseFieldTags is `url` attribute is set.
