### PR TITLE
The value of the placeholder should be null and not the same as the text

### DIFF
--- a/fof/form/field/model.php
+++ b/fof/form/field/model.php
@@ -187,7 +187,7 @@ class F0FFormFieldModel extends F0FFormFieldList implements F0FFormField
 
 		if (!empty($nonePlaceholder))
 		{
-			$options[] = JHtml::_('select.option', JText::_($nonePlaceholder), null);
+			$options[] = JHtml::_('select.option', null, JText::_($nonePlaceholder));
 		}
 
 		// Process field atrtibutes


### PR DESCRIPTION
When you use an empty placeholder for the model form field, the value of its option tag should be empty, and not the same value of the text.