### PR TITLE
Parse error: syntax error, unexpected '$this', form/field/tag.php on lin...

### DIFF
--- a/fof/form/field/tag.php
+++ b/fof/form/field/tag.php
@@ -241,7 +241,7 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 			$html .= '</span>';
 		}
 
-		return '<span class="' $this->id . ' ' . $class . '">' .
+		return '<span class="' . $this->id . ' ' . $class . '">' .
 			$html .
 			'</span>';
 	}


### PR DESCRIPTION
...e 244

A customer has just sent us ticket with this error:

Parse error: syntax error, unexpected '$this', form/field/tag.php on line 244
https://github.com/akeeba/fof/blob/development/fof/form/field/tag.php#L244

The error is being included in FoF 2.4.2 and rev20042FD-1426285324.