### PR TITLE
Added backsplash to namespace

### DIFF
--- a/fof/Form/Form.php
+++ b/fof/Form/Form.php
@@ -651,7 +651,7 @@ class Form extends JForm
 			list($prefix, $type) = explode('.', $type);
 
 			array_unshift($plainPrefixes, $prefix);
-			array_unshift($namespacedPrefixes, $prefix);
+			array_unshift($namespacedPrefixes, $prefix . '\\');
 		}
 
 		// First try to find the namespaced class


### PR DESCRIPTION
We need a \\ to the `$namespacedPrefixes` else if I use a field `type="Space.ordering"` the $class will be SpaceForm\...