### PR TITLE
Fixed floating sidebar and messages

### DIFF
--- a/fof/Render/AkeebaStrapper.php
+++ b/fof/Render/AkeebaStrapper.php
@@ -102,7 +102,7 @@ class AkeebaStrapper extends RenderBase implements RenderInterface
 				// We have a floating sidebar, they said. It looks great, they said. They must've been blind, I say!
 				'j-toggle-main',
 				'j-toggle-transition',
-				'span12',
+				'row-fluid',
 			);
 
 			$classes = array_unique($classes);

--- a/fof/Render/Joomla3.php
+++ b/fof/Render/Joomla3.php
@@ -86,7 +86,7 @@ class Joomla3 extends AkeebaStrapper
 				// We have a floating sidebar, they said. It looks great, they said. They must've been blind, I say!
 				'j-toggle-main',
 				'j-toggle-transition',
-				'span12',
+				'row-fluid',
 			);
 
 			$classes = array_unique($classes);


### PR DESCRIPTION
![umrf](https://cloud.githubusercontent.com/assets/2734125/8267999/01237842-17a0-11e5-955f-2c72ecc89369.png)

`span12` doen't work correctly with the message. Switched to `row-fluid` instead.