### PR TITLE
Apply CMS PR #5630

### DIFF
--- a/fof/form/field/tag.php
+++ b/fof/form/field/tag.php
@@ -112,15 +112,6 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 			$this->value = $db->loadColumn();
 		}
 
-		// Ajax tag only loads assigned values
-		if (!$this->isNested())
-		{
-			// Only item assigned values
-			$values = (array) $this->value;
-            F0FUtilsArray::toInteger($values);
-			$query->where('a.id IN (' . implode(',', $values) . ')');
-		}
-
 		// Filter language
 		if (!empty($this->element['language']))
 		{

--- a/fof/form/field/tag.php
+++ b/fof/form/field/tag.php
@@ -80,7 +80,7 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 
 		$db		= F0FPlatform::getInstance()->getDbo();
 		$query	= $db->getQuery(true)
-			->select('a.id AS value, a.path, a.title AS text, a.level, a.published')
+			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, ')
 			->from('#__tags AS a')
 			->join('LEFT', $db->quoteName('#__tags') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
@@ -118,7 +118,7 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 			$query->where('a.language = ' . $db->quote($this->element['language']));
 		}
 
-		$query->where($db->quoteName('a.alias') . ' <> ' . $db->quote('root'));
+		$query->where($db->qn('a.lft') . ' > 0');
 
 		// Filter to only load active items
 
@@ -133,8 +133,7 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 			$query->where('a.published IN (' . implode(',', $published) . ')');
 		}
 
-		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.parent_id, a.published, a.path')
-			->order('a.lft ASC');
+		$query->order('a.lft ASC');
 
 		// Get the options.
 		$db->setQuery($query);

--- a/fof/form/field/tag.php
+++ b/fof/form/field/tag.php
@@ -80,7 +80,7 @@ class F0FFormFieldTag extends JFormFieldTag implements F0FFormField
 
 		$db		= F0FPlatform::getInstance()->getDbo();
 		$query	= $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, ')
+			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft')
 			->from('#__tags AS a')
 			->join('LEFT', $db->quoteName('#__tags') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 


### PR DESCRIPTION
Came across this when a setting ```multiple="false"``` on a tag field and no options showed. Removing the code as was done in https://github.com/joomla/joomla-cms/pull/5630 Fixed the issue

I also applied the SQL optimisation PR that we applied in the CMS (https://github.com/joomla/joomla-cms/pull/4114 but with the fix for postgres in https://github.com/joomla/joomla-cms/pull/4842)