### PR TITLE
Array to string conversion in uninstallPostInstallationMessages

### DIFF
--- a/fof/utils/installscript/installscript.php
+++ b/fof/utils/installscript/installscript.php
@@ -2353,7 +2353,7 @@ abstract class F0FUtilsInstallscript
 		$extension_id = array_shift($ids);
 
 		$query = $db->getQuery(true)
-			->delete($this->postInstallationMessages)
+			->delete($db->qn('#__postinstall_messages'))
 			->where($db->qn('extension_id') . ' = ' . $db->q($extension_id));
 
 		try


### PR DESCRIPTION
Hi,

uninstallPostInstallationMessages is deleting from array $this->postInstallationMessages, instead of naming the table '#__postinstall_messages'.

To avoid the notice, I have replaced the array with the table.