### PR TITLE
Fixed creation with json apis

### DIFF
--- a/fof/Controller/DataController.php
+++ b/fof/Controller/DataController.php
@@ -190,13 +190,10 @@ class DataController extends Controller
 		// Alter the task based on the verb
 		switch ($requestMethod)
 		{
-			// POST and PUT result in a record being saved, as long as there is an ID
+			// POST and PUT result in a record being saved; no ID means creating a new record
 			case 'POST':
 			case 'PUT':
-				if ($id)
-				{
-					$task = 'save';
-				}
+				$task = 'save';
 				break;
 
 			// DELETE results in a record being deleted, as long as there is an ID


### PR DESCRIPTION
Previously it was not possible to create new records through the apis.

Btw, i found new issues related to this:

1) When there is an error in saving, the error is not propagated as an HTTP error but instead it uses the joomla way of enqueueMessage and redirect, which is not how it should work in the REST world

2) When the saving goes well, the system redirects to the read / edit view but skips the format part, so instead of showing the record in json, it prints out the html version of the page.

I can fix these, but i would need some pointing on how: throw / catch and intercept when json, create a onAfterSave / something on the json view class...? 
You call @nikosdion :)