### PR TITLE
Akeeba Strapper : Fix sidebar

### DIFF
--- a/fof/Render/AkeebaStrapper.php
+++ b/fof/Render/AkeebaStrapper.php
@@ -703,7 +703,9 @@ HTML;
 		// Get and output the sidebar, if present
 		$sidebar = \JHtmlSidebar::render();
 
-		if ($show_filters && !empty($sidebar))
+		if ($show_filters && !empty($sidebar)
+			&& (!$this->container->platform->isFrontend() || $this->container->toolbar->getRenderFrontendSubmenu())
+		)
 		{
 			$html .= '<div id="j-sidebar-container" class="span2">' . "\n";
 			$html .= "\t$sidebar\n";


### PR DESCRIPTION
Small fix. When the sidebar is not used in front, the sidebar container
(span2) should not be outputed.