### PR TITLE
In Joomla 3.3 we don't need to worry about magic quotes

### DIFF
--- a/fof/Input/Input.php
+++ b/fof/Input/Input.php
@@ -94,14 +94,6 @@ class Input extends \JInput
 			$hash = 'REQUEST';
 		}
 
-		// Magic quotes GPC handling (something JInput simply can't handle at all)
-		// @codeCoverageIgnoreStart
-		if (($hash == 'REQUEST') && get_magic_quotes_gpc() && class_exists('\\JRequest', true))
-		{
-			$source = \JRequest::get('REQUEST', 2);
-		}
-		// @codeCoverageIgnoreEnd
-
 		parent::__construct($source, $options);
 	}
 


### PR DESCRIPTION
In FOF 3 we require PHP 5.3+ this means magic quotes are deprecated and in Joomla 3.x which we also require they are required to be disabled. So we don't need to use JInput anymore (yay)