### PR TITLE
Use the AS parameter in the JDatabase API

### DIFF
--- a/fof/Model/DataModel/Relation/HasMany.php
+++ b/fof/Model/DataModel/Relation/HasMany.php
@@ -131,7 +131,7 @@ class HasMany extends Relation
 
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
-			->from($db->qn($foreignModel->getTableName()) . ' AS ' . $db->qn('reltbl'))
+			->from($db->qn($foreignModel->getTableName(), 'reltbl'))
 			->where($db->qn('reltbl') . '.' . $db->qn($foreignModel->getFieldAlias($this->foreignKey)) . ' = '
 				. $db->qn($tableAlias) . '.'
 				. $db->qn($this->parentModel->getFieldAlias($this->localKey)));


### PR DESCRIPTION
If you add a second parameter to quote name it will be used as the AS clause https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/database/driver.php#L1504