### PR TITLE
FormField Button : Allow parsing Tags

### DIFF
--- a/fof/Form/Field/Button.php
+++ b/fof/Form/Field/Button.php
@@ -123,7 +123,7 @@ class Button extends Text implements FieldInterface
 		$text     = $this->element['text'] ? (string) $this->element['text'] : '';
 		$class    = $this->class ? $this->class : '';
 		$icon     = $this->element['icon'] ? '<span class="icon ' . (string) $this->element['icon'] . '"></span> ' : '';
-		$onclick  = $this->onclick ? 'onclick="' . $this->onclick . '"' : '';
+		$onclick  = $this->onclick ? 'onclick="' . $this->parseFieldTags((string) $this->onclick) . '"' : '';
 		$url      = $this->element['url'] ? 'href="' . $this->parseFieldTags((string) $this->element['url']) . '"' : '';
 		$title    = $this->element['title'] ? 'title="' . JText::_((string) $this->element['title']) . '"' : '';
 		$useValue = in_array((string) $this->element['use_value'], array('true', '1', 'on', 'yes'));


### PR DESCRIPTION
When Button is used in list the onclick event is now parsed and so then can allow allow sending javascript with [ITEM:data]
Example for edit button : onclick="listItemTask('cb[ITEM:ID]', 'edit')"
