### PR TITLE
We aren't checking in the layouts directory

### DIFF
--- a/fof/Layout/LayoutFile.php
+++ b/fof/Layout/LayoutFile.php
@@ -59,7 +59,7 @@ class LayoutFile extends JLayoutFile
 			$possiblePaths = array(
 				$prefix . '/templates/' . $this->container->platform->getTemplate() . '/html/layouts/' . $filePath,
 				$this->basePath . '/' . $filePath,
-				$platformDirs['root'] . '/' . $filePath
+				$platformDirs['root'] . '/layouts/' . $filePath
 			);
 
 			reset($files);


### PR DESCRIPTION
Currently when you do something like

```php
echo \FOF30\Layout\LayoutHelper::render($this->getContainer(), 'joomla.form.renderfield', array('input' => '<input type="text" name="variable" value="' . $this->getModel()->variable . '" />', 'label' => '<label>Label For some variable</label>', 'options' => array()));
```

You get nothing back. This is because we are looking in `JOOMLA_ROOT/joomla/form/renderfield.php` instead of `JOOMLA_ROOT/layouts/joomla/form/renderfield.php`