### PR TITLE
Only show published buttons if a enabled field is present

### DIFF
--- a/fof/Toolbar/Toolbar.php
+++ b/fof/Toolbar/Toolbar.php
@@ -315,11 +315,21 @@ class Toolbar
 			JToolBarHelper::divider();
 		}
 
-		if ($this->perms->editstate)
+		// Published buttons are only added if there is a enabled field in the table
+		try
 		{
-			JToolBarHelper::publishList();
-			JToolBarHelper::unpublishList();
-			JToolBarHelper::divider();
+			$model = $this->container->factory->model($view);
+
+			if ($model->hasField('enabled') && $this->perms->editstate)
+			{
+				JToolBarHelper::publishList();
+				JToolBarHelper::unpublishList();
+				JToolBarHelper::divider();
+			}
+		}
+		catch (\Exception $e)
+		{
+			// Yeah. Let's not add the buttons if we can't load the model...
 		}
 
 		if ($this->perms->delete)


### PR DESCRIPTION
This applies very similar code to that as done for the checkin button in the same method. If there is no `enabled` field present then there's no point in showing the published buttons.

I don't think this could fall under b/c because the `DataModel::published()` bails super early if there is no `enabled` field present