### PR TITLE
Make it possible for the csv to access relations using the syntax rel…

### DIFF
--- a/fof/View/DataView/Csv.php
+++ b/fof/View/DataView/Csv.php
@@ -161,7 +161,36 @@ class Csv extends Html implements DataViewInterface
 
 				foreach ($this->csvFields as $f)
 				{
+					$exist = false;
+
+					// If we have a dot, we are dealing with relations
+					if (strpos($f, '.'))
+					{
+						$methods = explode('.', $f);
+
+						$object = $item;
+
+						// Let's see if the relation exists
+						foreach ($methods as $method)
+						{
+							if (isset($object->$method))
+							{
+								$exist = true;
+								$object = $object->$method;
+							}
+							else
+							{
+								$exist = false;
+								break;
+							}
+						}
+					}
+
 					if (in_array($f, $keys))
+					{
+						$temp[] = $f;
+					}
+					elseif($exist)
 					{
 						$temp[] = $f;
 					}
@@ -193,7 +222,22 @@ class Csv extends Html implements DataViewInterface
 
 				foreach ($keys as $k)
 				{
-                    $v = $item->$k;
+					// If our key contains a dot, then we are trying to access a relation
+					if (strpos($k, '.'))
+					{
+						$methods = explode('.', $k);
+						$v = $item;
+
+						foreach ($methods as $method)
+						{
+							$v = $v->$method;
+						}
+					}
+					else
+					{
+						$v = $item->$k;
+					}
+
 
 					if (is_array($v))
 					{


### PR DESCRIPTION
….property

The default csv export works great for properties that belong to the datamodel, but it was not possible to access any relations that the model could have. 

With this patch you could define your fields like:
```php
	protected $csvFields = array(
		'user.birthdate',
		'user.user.name'
	);
```

The first item would try to query the user relation. The second one would call the user relation on the user object etc. You can go as deep as you need. 

This works on on hasOne relations. 