### PR TITLE
Add event when saving fails

### DIFF
--- a/fof/Controller/DataController.php
+++ b/fof/Controller/DataController.php
@@ -1389,6 +1389,9 @@ class DataController extends Controller
 		{
 			$status = false;
 			$error = $e->getMessage();
+
+			$eventName = 'onAfterApplySaveError';
+			$result = $this->triggerEvent($eventName, array(&$data, $model->getId(), $e));
 		}
 
 		if (!$status)


### PR DESCRIPTION
When saving data has prerequisites (e.g. creating a user) this can be done in the `onBeforeApplySave` method. However is there is an error during the save operation then sometimes the operations need to be 'undone' but currently no method is triggered (if there is an exception thrown in save then the `onAfterApplySave` method is never triggered - and even if it was you wouldn't be able to tell if it was successful or not with the current parameters anyhow.

If gh-547 is merged then this will need to be updated