### PR TITLE
Inflector bug. lowercase fix.

### DIFF
--- a/fof/Inflector/Inflector.php
+++ b/fof/Inflector/Inflector.php
@@ -164,7 +164,6 @@ class Inflector
 	public function pluralize($word)
 	{
 		$word = strtolower($word);
-
 		// Get the cached noun of it exists
 		if (isset($this->cache['pluralized'][$word]))
 		{
@@ -210,12 +209,14 @@ class Inflector
 	 */
 	public function singularize($word)
 	{
+		$word = strtolower($word);
+
 		// Get the cached noun of it exists
 		if (isset($this->cache['singularized'][$word]))
 		{
 			return $this->cache['singularized'][$word];
 		}
-		
+
 		// Check if the noun is already in singular form, i.e. in the pluralized cache
 		if (isset($this->cache['pluralized'][$word]))
 		{

--- a/fof/Inflector/Inflector.php
+++ b/fof/Inflector/Inflector.php
@@ -163,6 +163,8 @@ class Inflector
 	 */
 	public function pluralize($word)
 	{
+		$word = strtolower($word);
+
 		// Get the cached noun of it exists
 		if (isset($this->cache['pluralized'][$word]))
 		{


### PR DESCRIPTION
When inflector tries to translate triad names, they are received whit first capital letter. So the custom words in cache cannot be found.
This fix permits to custom the pairs of singular/plural for the triad files.