### PR TITLE
empty() returns false even when there are no items in a collection

### DIFF
--- a/fof/View/DataView/Csv.php
+++ b/fof/View/DataView/Csv.php
@@ -144,7 +144,7 @@ class Csv extends Html implements DataViewInterface
 		else
 		{
 			// Default CSV behaviour in case the template isn't there!
-			if (empty($items))
+			if (count($items) === 0)
 			{
 				throw new AccessForbidden;
 			}


### PR DESCRIPTION
Haven't had time to debug why empty isn't working - I just got as far as debugging that it wasn't but this did work