### PR TITLE
Generate CSV file with CSV extension type

### DIFF
--- a/fof/View/DataView/Csv.php
+++ b/fof/View/DataView/Csv.php
@@ -70,7 +70,7 @@ class Csv extends Html implements DataViewInterface
 		{
 			$view = $this->input->getCmd('view', 'cpanel');
 			$view = $this->container->inflector->pluralize($view);
-			$this->csvFilename = strtolower($view);
+			$this->csvFilename = strtolower($view) . '.csv';
 		}
 
 		if (array_key_exists('csv_fields', $config))


### PR DESCRIPTION
When no CSV File name is specified and the default one is used you just have a file downloaded of the format 

`myView` rather than `myView.csv`