### PR TITLE
Allow viewing on old record status in onBeforeUpdate

### DIFF
--- a/fof/Model/DataModel.php
+++ b/fof/Model/DataModel.php
@@ -1039,7 +1039,7 @@ class DataModel extends Model implements \JTableInterface
 		// If we have relations we keep a copy of the data before bind.
 		if (count($relationImportantFields))
 		{
-			$dataBeforeBind = array_merge($this->recordData);
+			$dataBeforeBind = $this->recordData;
 		}
 
 		// Bind any (optional) data. If no data is provided, the current record data is used
@@ -1089,7 +1089,7 @@ class DataModel extends Model implements \JTableInterface
 		}
 		else
 		{
-			$this->triggerEvent('onBeforeUpdate', array(&$dataObject));
+			$this->triggerEvent('onBeforeUpdate', array(&$dataObject, $dataBeforeBind));
 
 			$db->updateObject($this->tableName, $dataObject, $this->idFieldName, true);
 


### PR DESCRIPTION
I'm not 100% if it's better to even clone the model and inject the whole model - but as `$dataBeforeBind` already exists - it would appear to make sense to use that.

I've had several cases when updating a record I need to look at the previous value - but I either have to add a check in `onBeforeSave` for if the record exists OR I have to add have the data available before bind in `onBeforeUpdate` - so i'm going with the latter approach here.

In all honesty I'd kinda expect the `onBeforeUpdate` and `onBeforeCreate` events to be thrown at the same time as `onBeforeSave` (i.e. before the bind) but as for b/c we can't do that I guess this is the next best alternative?