### PR TITLE
Update Controller.php

### DIFF
--- a/fof/Controller/Controller.php
+++ b/fof/Controller/Controller.php
@@ -911,7 +911,7 @@ class Controller
 		if (method_exists($session, 'getToken'))
 		{
 			$token    = $session->getToken();
-			$hasToken = $this->input->get($token, false, 'none') == 1;
+			$hasToken = $session->hasToken($token);
 
 			if (!$hasToken)
 			{
@@ -925,7 +925,7 @@ class Controller
 			if (method_exists($session, 'getFormToken'))
 			{
 				$token    = $session->getFormToken();
-				$hasToken = $this->input->get($token, false, 'none') == 1;
+				$hasToken = $session->hasToken($token);
 
 				if (!$hasToken)
 				{


### PR DESCRIPTION
This is the correct method to check the token because trying to get it from the input data get problems with servers that use some caching systems like Varnish or other when the token is manually reset from a specific cache-system pilot plugin.

Running a component made in FOF in the SiteGround hosting, always get 403 forbidden errors due this wrong check procedure.

If you need more explanations ask to me.