### PR TITLE
Manage 1-N relation

### DIFF
--- a/fof/Form/Field/Relation.php
+++ b/fof/Form/Field/Relation.php
@@ -62,6 +62,11 @@ class Relation extends GenericList
 
 		$rels = array();
 
+		if ($relations instanceof DataModel)
+		{
+			$relations = array($relations);
+		}
+
 		foreach ($relations as $relation) {
 
 			$html = '<span class="' . $relationclass . '">';


### PR DESCRIPTION
If `getData` return a normal model (1-N relation) the foreach is never triggered.