### PR TITLE
Added new saveRelations() method to belongsToMany

### DIFF
--- a/fof/Model/DataModel/Relation/BelongsToMany.php
+++ b/fof/Model/DataModel/Relation/BelongsToMany.php
@@ -323,6 +323,14 @@ class BelongsToMany extends Relation
 		// Save all related items
 		parent::saveAll();
 
+		$this->saveRelations();
+	}
+
+	/**
+	 * Overwrite the pivot table data with the new associations
+	 */
+	public function saveRelations()
+	{
 		// Get all the new keys
 		$newKeys = array();
 


### PR DESCRIPTION
Allows to save the relation's "links" without saving the object themselves

# Usage

Normal way of saving items + relations

```php
<?php

// The related Ids to attach
$ids = array(1, 2, 3);

$this->find(1);

$roles = $user->getContainer()->factory->model('Roles')->tmpInstance();

$newRoles = $roles->where(
    $roles->getIdFieldName(), 'in', $ids
)->get();

foreach($newRoles as $newRole) {
    $this->roles->add($newRole);
}

$this->getRelations()->save('roles');
```

This saves the related items themselves before saving the links, which is not always required and kind of heavy in most cases

With this new method you can also do

```php
<?php

// The related Ids to attach
$ids = array(1, 2, 3);

$this->find(1);

$roles = $user->getContainer()->factory->model('Roles')->tmpInstance();

$newRoles = $roles->where(
    $roles->getIdFieldName(), 'in', $ids
)->get();

foreach($newRoles as $newRole) {
    $this->roles->add($newRole);
}

$this->getRelations()->getRelation('roles')->saveRelations();
```

which will just save the link in the pivot table