### PR TITLE
Reallowed empty value for Calendar field

### DIFF
--- a/fof/Form/Field/Calendar.php
+++ b/fof/Form/Field/Calendar.php
@@ -232,8 +232,16 @@ class Calendar extends \JFormFieldCalendar implements FieldInterface
 		}
 		else
 		{
-			$jDate = new \JDate($this->value);
-			$value = strftime($format, $jDate->getTimestamp());
+			if (!$this->value
+				&& (string) $this->element['empty_replacement'])
+			{
+				$value = $this->element['empty_replacement'];
+			}
+			else
+			{
+				$jDate = new \JDate($this->value);
+				$value = strftime($format, $jDate->getTimestamp());
+			}
 
 			return '<span class="' . $this->id . ' ' . $class . '">' .
 			htmlspecialchars($value, ENT_COMPAT, 'UTF-8') .


### PR DESCRIPTION
After updating FOF3, a client got a small BC break on the Calendar.

On browse view the original behaviour for `empty` dates was to not show them. But now the behaviour is to show the today date.

Well, the change was make 1 year ago... so I'm not sure which one using.

So I made a compromise and added `empty_replacement` param. If the param is not set the current behaviour will apply. Else it will show the `empty_replacement`.