### PR TITLE
Fix database check on column type

### DIFF
--- a/fof/database/installer.php
+++ b/fof/database/installer.php
@@ -520,7 +520,7 @@ class F0FDatabaseInstaller
 			case 'type':
 				try
 				{
-					$tableColumns = $this->db->getTableColumns($tableNormal, true);
+					$tableColumns = $this->db->getTableColumns($tableNormal, false);
 				}
 				catch (\Exception $e)
 				{
@@ -536,7 +536,7 @@ class F0FDatabaseInstaller
 					if (!empty($coltype))
 					{
 						$coltype = strtolower($coltype);
-						$currentType = strtolower($tableColumns[$value]);
+						$currentType = strtolower($tableColumns[$value]->Type);
 
 						$condition = ($coltype == $currentType);
 					}

--- a/fof/database/installer.php
+++ b/fof/database/installer.php
@@ -536,7 +536,7 @@ class F0FDatabaseInstaller
 					if (!empty($coltype))
 					{
 						$coltype = strtolower($coltype);
-						$currentType = strtolower($tableColumns[$value]->Type);
+						$currentType = strtolower($tableColumns[$value]);
 
 						$condition = ($coltype == $currentType);
 					}


### PR DESCRIPTION
Commit 259256822d1772b88b234a055fca55d8ebb5dc97 changed the way we are fetching the column list, from an array of objects to an array of strings.
I suspect that was a copy/paste error, this PR reverts to the old behavior (array of objects)