### PR TITLE
Display menuitems in sidebar based on "group title" or "user id"

### DIFF
--- a/fof/GroupsViewAcl/GroupsViewAcl.php
+++ b/fof/GroupsViewAcl/GroupsViewAcl.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @package    FOF
+ * @copyright  2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license    GNU GPL version 2 or later
+ */
+
+namespace FOF30\GroupsViewAcl;
+
+use /** @noinspection PhpUndefinedClassInspection */
+	\JFactory;
+use /** @noinspection PhpUndefinedClassInspection */
+	\JText;
+/**
+ * Collection of methods to extend handling of groups
+ *
+ * @package  FOF30\GroupsViewAcl
+ *
+ * @since    3.0
+ */
+class GroupsViewAcl
+{
+	/**
+	 * Get the GroupId's corresponding to the grop names
+	 *
+	 * @param   array|string  $groupNames  empty strings are ignored
+	 *
+	 * @return array
+	 *
+	 * @throws \RuntimeException
+	 *
+	 * @since version
+	 */
+	public static function getGroupIdsByNames($groupNames)
+	{
+		/** @noinspection PhpUndefinedClassInspection */
+		$db = JFactory::getDbo();
+
+		if (is_string($groupNames))
+		{
+			// Convert to string to array
+			$groupNamesArr = ($groupNames === '') ? array() : array($groupNames);
+		}
+		elseif (is_array($groupNames))
+		{
+			$groupNamesArr = (array) $groupNames;
+		}
+		else
+		{
+			/** @noinspection PhpUndefinedClassInspection */
+			throw new \RuntimeException(JText::_('LIB_FOF_GROUPSVIEWACL_INVALID_GROUPNAMES_TYPE'));
+			/** @noinspection PhpUnreachableStatementInspection we need to please codesniffer */
+			$groupNamesArr = array();
+		}
+
+		$where = array();
+
+		foreach ($groupNamesArr as $name)
+		{
+			if ($name !== '')
+			{
+				$where[] = $db->quoteName('title') . ' like ' . $db->quote($name);
+			}
+		}
+
+		$where = implode(' OR ', $where);
+
+		$query = $db->getQuery(true);
+		$query
+			->select($db->quoteName('id'))
+			->from($db->quoteName('#__usergroups'));
+
+		/** @noinspection IsEmptyFunctionUsageInspection */
+		if (!empty($where))
+		{
+			$query->where($where);
+		}
+
+		$db->setQuery($query);
+
+		return $db->loadColumn();
+	}
+}

--- a/fof/Toolbar/Toolbar.php
+++ b/fof/Toolbar/Toolbar.php
@@ -708,9 +708,9 @@ class Toolbar
 					// $groupid          =   (array) $xml->foflib->viewaccess->groupid;
 					// $accesslevelname  =   (array) $xml->foflib->viewaccess->accesslevelname;
 
-					if ( ! $validated )
+					if ( ! $validated && ( $groupnames || $userids ) )
 					{
-						// no matching users or groups is that same as skipping
+						// no matching users or groups ( but rules specified ) is the same as skipping
 						continue;
 					}
 

--- a/fof/Toolbar/Toolbar.php
+++ b/fof/Toolbar/Toolbar.php
@@ -667,6 +667,53 @@ class Toolbar
 				{
 					$using_meta = true;
 					$xml = simplexml_load_file($searchPath . '/' . $view . '/' . $meta[0]);
+
+					/*	place metadata.xml file in the view directory ( as with skip.xml
+						<?xml version="1.0" encoding="utf-8"
+						<viewmetadata>
+							<foflib>
+								<ordering>99</ordering>
+								<viewaccess>
+									<!-- can have muliple entries for userid or groupname -->
+									<userid>42</userid>
+									<groupname>ViryaDevelopment</groupname>
+								</viewaccess>
+							</foflib>
+						</viewmetadata>
+					*/
+					$validated = false;
+
+					// validating agains userids should only be used in a development context where we want to limit the
+					// risk of a customer assigning themselves to a group and thus wreak havoc
+					$userids            = (array) $xml->foflib->viewaccess->userid;
+					if ( $userids )
+					{
+						$userId         = $this->container->platform->getUser()->id;
+						$validated      = array_search($userId,$userids) !== false ? true : false;
+					}
+
+					// specify the group names and thus controll the visibility of a sidebare menu item
+					$groupnames         = (array) $xml->foflib->viewaccess->groupname;
+					if ( ! $validated && $groupnames )
+					{
+						$groupnamesIds = GroupsViewAcl::getGroupIdsByNames($groupnames);
+						if ( $groupnamesIds )
+						{
+							$user          = $this->container->platform->getUser();
+							$groups        = $user->groups;
+							$validated     = array_intersect($groups,$groupnamesIds);
+						}
+					}
+					// If so desired we could add "groupid" and "accesslevelname"
+					// $groupid          =   (array) $xml->foflib->viewaccess->groupid;
+					// $accesslevelname  =   (array) $xml->foflib->viewaccess->accesslevelname;
+
+					if ( ! $validated )
+					{
+						// no matching users or groups is that same as skipping
+						continue;
+					}
+
 					$order = (int)$xml->foflib->ordering;
 				}
 				else

--- a/fof/language/en-GB/en-GB.lib_fof30.ini
+++ b/fof/language/en-GB/en-GB.lib_fof30.ini
@@ -58,3 +58,5 @@ LIB_FOF_TOOLBAR_ERR_UNKNOWNBUTTONTYPE="Unknown button type %s"
 LIB_FOF_VIEW_MODELNOTINVIEW="The model %s does not exist in view %s"
 LIB_FOF_VIEW_UNRECOGNISEDEXTENSION="FOF: Unrecognised extension in view template %s"
 LIB_FOF_VIEW_POSSIBLYSUHOSIN="FOF: Could not write to your cache directory. Please make your cache directories (cache and administrator/cache under your site's root) writeable to PHP by changing the permissions. If you do not understand what this means please contact your host and paste this entire message to them."
+
+LIB_FOF_GROUPSVIEWACL_INVALID_GROUPNAMES_TYPE="Oops, $groupNames should be passed as array or string"


### PR DESCRIPTION
2nd time is a charm.. 
Display menuitems in sidebar based on "group title" or "user id".
Extend the definition of meta metadata.xml, if no viewaccess is defined, item is shown.
If viewmetadata is specified, current users settings are tested against it and only displayed
if the user matches

	<?xml version="1.0" encoding="utf-8"
	<viewmetadata>
		<foflib>
			<ordering>99</ordering>
			<viewaccess>
				<!-- can have muliple entries for userid or groupname -->
				<userid>42</userid>
				<groupname>ViryaDevelopment</groupname>
			</viewaccess>
		</foflib>
	</viewmetadata>