### PR TITLE
Relation Form Field [relationclass] attribute

### DIFF
--- a/fof/Form/Field/Relation.php
+++ b/fof/Form/Field/Relation.php
@@ -124,9 +124,11 @@ class Relation extends GenericList
 		$this->value = array();
 
 		$value_field = $this->element['value_field'] ? (string) $this->element['value_field'] : 'title';
+		$name = (string) $this->element['name'];
+        	$class = $this->element['relationclass'] ? (string) $this->element['relationclass'] : $name;
 
 		$view      = $this->form->getView()->getName();
-		$relation  = $this->form->getModel()->getContainer()->inflector->pluralize((string) $this->element['name']);
+		$relation  = $this->form->getModel()->getContainer()->inflector->pluralize($class);
 
 		/** @var DataModel $model */
 		$model = $this->form->getContainer()->factory->model($relation)->setIgnoreRequest(true)->savestate(false);
@@ -142,7 +144,7 @@ class Relation extends GenericList
 		if ($id = $this->form->getModel()->getId())
 		{
 			$model     = $this->form->getModel();
-			$relations = $model->$relation;
+			$relations = $model->$name;
 
 			foreach ($relations as $item)
 			{


### PR DESCRIPTION
Relation Form Field now takes into account he parameter [relationclass] even in edit views, for cases when the field name is not the same of the model class name (ie: company_types vs CompanyTypes)