### PR TITLE
Export also null fields in CSV

### DIFF
--- a/fof/View/DataView/Csv.php
+++ b/fof/View/DataView/Csv.php
@@ -171,7 +171,7 @@ class Csv extends Html implements DataViewInterface
 						// Let's see if the relation exists
 						foreach ($methods as $method)
 						{
-							if (isset($object->$method))
+							if (isset($object->$method) || property_exists($object, $method))
 							{
 								$exist = true;
 								$object = $object->$method;


### PR DESCRIPTION
It can happen that the first model in the csv list to export has some null fields.
If this happens, those fields do not get exported even if some record afterwards has it because isset() checks for null value.
Adding property_exists avoids that case