### PR TITLE
Test against HHVM current and PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,20 @@ matrix:
             - mysql-client-5.6
       services:
         - mysql
+      env: JVERSION_TEST=3.4
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next travis ci update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: JVERSION_TEST=3.5-dev      
   allow_failures:
      - php: hhvm
      - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ php:
   - 7.0
   - 5.6
   - 5.5
-  - 5.4
-  - 5.3
 
 env:
   - JVERSION_TEST=3.4
@@ -52,10 +50,6 @@ matrix:
      - php: 5.6
        env: JVERSION_TEST=3.5-dev
      - php: 5.5
-       env: JVERSION_TEST=3.5-dev
-     - php: 5.4
-       env: JVERSION_TEST=3.5-dev
-     - php: 5.3
        env: JVERSION_TEST=3.5-dev
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,36 @@ git:
 
 language: php
 php:
+  - 7.1
   - 7.0
   - 5.6
   - 5.5
   - 5.4
   - 5.3
-  - hhvm
+
+env:
+  global:
+    - JVERSION_TEST=3.4
+    - JVERSION_TEST=3.5-dev
 
 matrix:
+  fast_finish: true
+  include:
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next travis ci update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
   allow_failures:
      - php: hhvm
+     - php: 7.1
      - php: 7.0
      - php: 5.6
        env: JVERSION_TEST=3.5-dev
@@ -24,10 +44,6 @@ matrix:
        env: JVERSION_TEST=3.5-dev
      - php: 5.3
        env: JVERSION_TEST=3.5-dev
-
-env:
-    - JVERSION_TEST=3.4
-    - JVERSION_TEST=3.5-dev
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ php:
   - 7.0
   - 5.6
   - 5.5
+  - 5.4
+  - 5.3
 
 env:
   - JVERSION_TEST=staging
-  - JVERSION_TEST=3.7.x
-  - JVERSION_TEST=4.0-dev
 
 matrix:
   fast_finish: true
@@ -31,44 +31,10 @@ matrix:
       services:
         - mysql
       env: JVERSION_TEST=staging
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next travis ci update
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
-      services:
-        - mysql
-      env: JVERSION_TEST=3.7.x      
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next travis ci update
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
-      services:
-        - mysql
-      env: JVERSION_TEST=4.0-dev
   allow_failures:
      - php: hhvm
      - php: 7.1
      - php: 7.0
-     - php: 5.6
-       env: JVERSION_TEST=3.7.x
-     - php: 5.6
-       env: JVERSION_TEST=4.0-dev
-     - php: 5.5
-       env: JVERSION_TEST=3.7.x
-     - php: 5.5
-       env: JVERSION_TEST=4.0-dev
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 5.5
 
 env:
-  - JVERSION_TEST=Staging
+  - JVERSION_TEST=staging
   - JVERSION_TEST=3.7.x
   - JVERSION_TEST=4.0-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ php:
   - 5.3
 
 env:
-  global:
-    - JVERSION_TEST=3.4
-    - JVERSION_TEST=3.5-dev
+  - JVERSION_TEST=3.4
+  - JVERSION_TEST=3.5-dev
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ php:
   - 5.5
 
 env:
-  - JVERSION_TEST=3.4
-  - JVERSION_TEST=3.5-dev
   - JVERSION_TEST=Staging
+  - JVERSION_TEST=3.7.x
+  - JVERSION_TEST=4.0-dev
 
 matrix:
   fast_finish: true
@@ -59,8 +59,7 @@ branches:
     - debug-travis
 
 before_install:
-  - if [[ "$JVERSION_TEST" == "Staging" ]]; then git clone -b staging https://github.com/joomla/joomla-cms.git Tests/environments/Staging; fi
-  - if [[ "$JVERSION_TEST" != "Staging" ]]; then git submodule update --init --recursive Tests/environments/"$JVERSION_TEST"; fi
+  - git clone -b "$JVERSION_TEST" https://github.com/joomla/joomla-cms.git Tests/environments/"$JVERSION_TEST"
 
 install:
   - composer selfupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
             - mysql-client-5.6
       services:
         - mysql
-      env: JVERSION_TEST=Staging
+      env: JVERSION_TEST=staging
     - php: hhvm
       sudo: true
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
 env:
   - JVERSION_TEST=3.4
   - JVERSION_TEST=3.5-dev
+  - JVERSION_TEST=Staging
 
 matrix:
   fast_finish: true
@@ -58,7 +59,8 @@ branches:
     - debug-travis
 
 before_install:
-  - git submodule update --init --recursive Tests/environments/"$JVERSION_TEST"
+  - if [[ "$JVERSION_TEST" == "Staging" ]]; then git clone -b staging https://github.com/joomla/joomla-cms.git Tests/environments/Staging; fi
+  - if [[ "$JVERSION_TEST" != "Staging" ]]; then git submodule update --init --recursive Tests/environments/"$JVERSION_TEST"; fi
 
 install:
   - composer selfupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
             - mysql-client-5.6
       services:
         - mysql
-      env: JVERSION_TEST=3.4
+      env: JVERSION_TEST=Staging
     - php: hhvm
       sudo: true
       dist: trusty
@@ -43,15 +43,32 @@ matrix:
             - mysql-client-5.6
       services:
         - mysql
-      env: JVERSION_TEST=3.5-dev      
+      env: JVERSION_TEST=3.7.x      
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next travis ci update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: JVERSION_TEST=4.0-dev
   allow_failures:
      - php: hhvm
      - php: 7.1
      - php: 7.0
      - php: 5.6
-       env: JVERSION_TEST=3.5-dev
+       env: JVERSION_TEST=3.7.x
+     - php: 5.6
+       env: JVERSION_TEST=4.0-dev
      - php: 5.5
-       env: JVERSION_TEST=3.5-dev
+       env: JVERSION_TEST=3.7.x
+     - php: 5.5
+       env: JVERSION_TEST=4.0-dev
 
 branches:
   only:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -63,7 +63,7 @@ if (version_compare(PHP_VERSION, '5.4.0', 'lt'))
 // Fixed timezone to preserve our sanity
 @date_default_timezone_set('UTC');
 
-$jversion_test = getenv('JVERSION_TEST') ? getenv('JVERSION_TEST') : '3.4';
+$jversion_test = getenv('JVERSION_TEST') ? getenv('JVERSION_TEST') : 'staging';
 
 TravisLogger::log(4, 'Including environment info. Joomla version: '.$jversion_test);
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -92,6 +92,12 @@ if(getenv('TRAVIS'))
 {
     TravisLogger::log(4, 'Including special Travis configuration file');
     require_once __DIR__ . '/config_travis.php';
+
+	// Set the test configuration site root if not set in travis
+	if (!isset($fofTestConfig['site_root'])
+	{
+		$fofTestConfig['site_root'] = $siteroot;
+	}
 }
 else
 {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -94,7 +94,7 @@ if(getenv('TRAVIS'))
     require_once __DIR__ . '/config_travis.php';
 
 	// Set the test configuration site root if not set in travis
-	if (!isset($fofTestConfig['site_root'])
+	if (!isset($fofTestConfig['site_root']))
 	{
 		$fofTestConfig['site_root'] = $siteroot;
 	}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -63,7 +63,7 @@ if (version_compare(PHP_VERSION, '5.4.0', 'lt'))
 // Fixed timezone to preserve our sanity
 @date_default_timezone_set('UTC');
 
-$jversion_test = getenv('JVERSION_TEST') ? getenv('JVERSION_TEST') : 'staging';
+$jversion_test = getenv('JVERSION_TEST') ? getenv('JVERSION_TEST') : '3.4';
 
 TravisLogger::log(4, 'Including environment info. Joomla version: '.$jversion_test);
 

--- a/Tests/environments.php
+++ b/Tests/environments.php
@@ -8,6 +8,4 @@
 $environments = array(
 	// The paths to Joomla cloned repo
 	'staging'     => realpath(__DIR__.'/environments/staging'),
-	'3.7.x' => realpath(__DIR__.'/environments/3.7.x'),
-	'4.0-dev' => realpath(__DIR__.'/environments/3.5-dev'),
 );

--- a/Tests/environments.php
+++ b/Tests/environments.php
@@ -8,4 +8,6 @@
 $environments = array(
 	// The paths to Joomla cloned repo
 	'staging'     => realpath(__DIR__.'/environments/staging'),
+	'3.4'         => realpath(__DIR__.'/environments/3.4'),
+	'3.5-dev'     => realpath(__DIR__.'/environments/3.5-dev'),
 );

--- a/Tests/environments.php
+++ b/Tests/environments.php
@@ -7,7 +7,7 @@
 
 $environments = array(
 	// The paths to Joomla cloned repo
-	'Staging'     => realpath(__DIR__.'/environments/Staging'),
+	'staging'     => realpath(__DIR__.'/environments/staging'),
 	'3.7.x' => realpath(__DIR__.'/environments/3.7.x'),
 	'4.0-dev' => realpath(__DIR__.'/environments/3.5-dev'),
 );

--- a/Tests/environments.php
+++ b/Tests/environments.php
@@ -7,7 +7,7 @@
 
 $environments = array(
 	// The paths to Joomla cloned repo
-	'3.4'     => realpath(__DIR__.'/environments/3.4'),
-	'3.5-dev' => realpath(__DIR__.'/environments/3.5-dev'),
-	'Staging' => realpath(__DIR__.'/environments/Staging'),
+	'Staging'     => realpath(__DIR__.'/environments/Staging'),
+	'3.7.x' => realpath(__DIR__.'/environments/3.7.x'),
+	'4.0-dev' => realpath(__DIR__.'/environments/3.5-dev'),
 );

--- a/Tests/environments.php
+++ b/Tests/environments.php
@@ -9,4 +9,5 @@ $environments = array(
 	// The paths to Joomla cloned repo
 	'3.4'     => realpath(__DIR__.'/environments/3.4'),
 	'3.5-dev' => realpath(__DIR__.'/environments/3.5-dev'),
+	'Staging' => realpath(__DIR__.'/environments/Staging'),
 );


### PR DESCRIPTION
- add PHP 7.1 to tests
- fix HHVM to run on current (3.15.x as of this PR ) rather than the HHVM 3.6.6 version Travis CI precise container is permanently stuck on.
- switch to git clone the joomla branches to test against since the git submodules do not stay current with joomla automatically, the git submodules are left for local testing.