### PR TITLE
Fix reset whereClauses

### DIFF
--- a/fof/Model/DataModel.php
+++ b/fof/Model/DataModel.php
@@ -2144,6 +2144,7 @@ class DataModel extends Model implements \JTableInterface
 	public function reset($useDefaults = true, $resetRelations = false)
 	{
 		$this->recordData = array();
+		$this->whereClauses = array();
 
 		foreach ($this->knownFields as $fieldName => $information)
 		{


### PR DESCRIPTION
I had issues with the TreeModel. The first find() worked fine, the next one failed. A simplified quote of my code:

	foreach ($ids as $id)
	{
		$this->treeModel->find($id);
	}

`whereClauses` was not reset which caused this issue. This PR fixed it.