### PR TITLE
Get the manifest by it's method in Joomla 3.4+

### DIFF
--- a/fof/Utils/InstallScript/Component.php
+++ b/fof/Utils/InstallScript/Component.php
@@ -774,7 +774,14 @@ class Component extends BaseInstaller
 		$componentId = $db->loadResult();
 
 		// Ok, now its time to handle the menus.  Start with the component root menu, then handle submenus.
-		$menuElement = $parent->get('manifest')->administration->menu;
+		if (method_exists($parent, 'getManifest'))
+		{
+			$menuElement = $parent->getManifest()->administration->menu;
+		}
+		else
+		{
+			$menuElement = $parent->get('manifest')->administration->menu;
+		}
 
 		// We need to insert the menu item as the last child of Joomla!'s menu root node. First let's make sure that
 		// it exists. Normally it should be the menu item with ID = 1.
@@ -956,7 +963,16 @@ class Component extends BaseInstaller
 		 * Process SubMenus
 		 */
 
-		if (!$parent->get('manifest')->administration->submenu)
+		if (method_exists($parent, 'getManifest'))
+		{
+			$submenu = $parent->getManifest()->administration->submenu;
+		}
+		else
+		{
+			$submenu = $parent->get('manifest')->administration->submenu;
+		}
+
+		if (!$submenu)
 		{
 			return true;
 		}
@@ -964,7 +980,7 @@ class Component extends BaseInstaller
 		$parent_id = $table->id;
 
 		/** @var \SimpleXMLElement $child */
-		foreach ($parent->get('manifest')->administration->submenu->menu as $child)
+		foreach ($submenu->menu as $child)
 		{
 			$data                 = array();
 			$data['menutype']     = 'main';


### PR DESCRIPTION
The function `get` is effectively deprecated as part of the documented change that `JInstallerAdapter` will no longer extend from JAdapterInstance (which has been the case since 3.4 - https://github.com/joomla/joomla-cms/blob/3.7.4/libraries/cms/installer/adapter.php#L21)

`JInstallerAdapter::getManifest` has been the replacement method since 3.4 - so as `InstallScript/Component.php` is supposed to support 3.3 and higher I've added a method exists check.

Also required for Joomla 4.0 compatibility where `JInstallerAdapter::get` has been removed