### PR TITLE
Fixed IP detection

### DIFF
--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,5 +1,5 @@
 # Running tests
-In order to run the tests, you have configure your environment:
+In order to run the tests, you have to configure your environment:
  1. Create a database for the tests
  2. Install required libraries with Composer
 
@@ -19,7 +19,8 @@ $fofTestConfig = array(
 );
 ```
 ### Install required libraries with Composer
-You simply have to run `php composer.phar update` in order to install and update all the required libraries.
+You simply have to run `php composer.phar install` in order to install all the required libraries.  
+If you want to update the composer dependencies, run `php composer.phar update`.
 
 ### How to run tests
 Inside the `Tests` folder you can find a shell file named `run-tests.sh`.

--- a/Tests/Stubs/Utils/IpStub.php
+++ b/Tests/Stubs/Utils/IpStub.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     FOF
+ * @copyright   2010-2017 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license     GNU GPL version 2 or later
+ */
+
+namespace FOF30\Tests\Stubs\Toolbar;
+
+use FOF30\Utils\Ip;
+
+class IpStub extends Ip
+{
+	public static $fakeIP = null;
+
+    public static function detectIP()
+	{
+		if (!is_null(static::$fakeIP))
+		{
+			return static::$fakeIP;
+		}
+
+		return parent::detectIP();
+	}
+}

--- a/Tests/Stubs/Utils/IpStub.php
+++ b/Tests/Stubs/Utils/IpStub.php
@@ -5,7 +5,7 @@
  * @license     GNU GPL version 2 or later
  */
 
-namespace FOF30\Tests\Stubs\Toolbar;
+namespace FOF30\Tests\Stubs\Utils;
 
 use FOF30\Utils\Ip;
 
@@ -13,7 +13,7 @@ class IpStub extends Ip
 {
 	public static $fakeIP = null;
 
-    public static function detectIP()
+    protected static function detectIP()
 	{
 		if (!is_null(static::$fakeIP))
 		{
@@ -21,5 +21,10 @@ class IpStub extends Ip
 		}
 
 		return parent::detectIP();
+	}
+
+	public static function detectAndCleanIP()
+	{
+		return parent::detectAndCleanIP();
 	}
 }

--- a/Tests/Utils/IpDataprovider.php
+++ b/Tests/Utils/IpDataprovider.php
@@ -7,11 +7,156 @@ class IpDataprovider
 		$data[] = array(
 			// test
 			array(
-
+				'fakeIP'   => '127.0.0.1',
+				'useFirst' => true
 			),
 			// check
 			array(
+				'case'   => 'Single IPv4, using the first one',
+				'result' => '127.0.0.1'
+			)
+		);
 
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '0:0:0:0:0:ffff:d1ad:35a7',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Single IPv6, using the first one',
+				'result' => '0:0:0:0:0:ffff:d1ad:35a7'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,0:0:0:0:0:ffff:d1ad:35a7',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'IPv4 and IPv6, using the first one',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,0:0:0:0:0:ffff:d1ad:35a7',
+				'useFirst' => false
+			),
+			// check
+			array(
+				'case'   => 'IPv4 and IPv6, using the last one',
+				'result' => '0:0:0:0:0:ffff:d1ad:35a7'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,1.1.1.1',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Two IPv4, using the first one',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,1.1.1.1',
+				'useFirst' => false
+			),
+			// check
+			array(
+				'case'   => 'Two IPv4, using the last one',
+				'result' => '1.1.1.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,1.1.1.1,2.2.2.2',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Three IPv4, using the first one',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,1.1.1.1,2.2.2.2',
+				'useFirst' => false
+			),
+			// check
+			array(
+				'case'   => 'Three IPv4, using the last one',
+				'result' => '2.2.2.2'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1, 1.1.1.1, 2.2.2.2',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Malformed IPs (1)',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1,  1.1.1.1,  2.2.2.2',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Malformed IPs (2)',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1 1.1.1.1 2.2.2.2',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Malformed IPs (3)',
+				'result' => '127.0.0.1'
+			)
+		);
+
+		$data[] = array(
+			// test
+			array(
+				'fakeIP'   => '127.0.0.1  1.1.1.1  2.2.2.2',
+				'useFirst' => true
+			),
+			// check
+			array(
+				'case'   => 'Malformed IPs (4)',
+				'result' => '127.0.0.1'
 			)
 		);
 

--- a/Tests/Utils/IpDataprovider.php
+++ b/Tests/Utils/IpDataprovider.php
@@ -1,0 +1,20 @@
+<?php
+
+class IpDataprovider
+{
+	public static function getDetectAndCleanIP()
+	{
+		$data[] = array(
+			// test
+			array(
+
+			),
+			// check
+			array(
+
+			)
+		);
+
+		return $data;
+	}
+}

--- a/Tests/Utils/IpTest.php
+++ b/Tests/Utils/IpTest.php
@@ -8,6 +8,7 @@
 namespace FOF30\Tests\Utils;
 
 use FOF30\Tests\Helpers\FOFTestCase;
+use FOF30\Tests\Stubs\Utils\IpStub;
 
 require_once 'IpDataprovider.php';
 
@@ -23,6 +24,15 @@ class IpTest extends FOFTestCase
 	 */
 	public function testDetectAndCleanIP($test, $check)
 	{
-		$this->markTestIncomplete();
+		$msg = 'Ip::detectIP %s - Case: '.$check['case'];
+
+		$ip = new IpStub();
+
+		$ip::$fakeIP = $test['fakeIP'];
+		$ip::setUseFirstIpInChain($test['useFirst']);
+
+		$result = $ip::detectAndCleanIP();
+
+		$this->assertEquals($check['result'], $result, $msg);
 	}
 }

--- a/Tests/Utils/IpTest.php
+++ b/Tests/Utils/IpTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     FOF
+ * @copyright   2010-2017 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license     GNU GPL version 2 or later
+ */
+
+namespace FOF30\Tests\Utils;
+
+use FOF30\Tests\Helpers\FOFTestCase;
+
+require_once 'IpDataprovider.php';
+
+/**
+ * @covers  \FOF30\Utils\Ip::<protected>
+ * @covers  \FOF30\Utils\Ip::<private>
+ */
+class IpTest extends FOFTestCase
+{
+	/**
+	 * @group			Ip
+	 * @dataProvider    IpDataprovider::getDetectAndCleanIP
+	 */
+	public function testDetectAndCleanIP($test, $check)
+	{
+		$this->markTestIncomplete();
+	}
+}

--- a/fof/Utils/Ip.php
+++ b/fof/Utils/Ip.php
@@ -417,18 +417,14 @@ class Ip
 	 * reporting the IPs of intermediate devices, like load balancers. Examples:
 	 * https://www.akeebabackup.com/support/admin-tools/13743-double-ip-adresses-in-security-exception-log-warnings.html
 	 * http://stackoverflow.com/questions/2422395/why-is-request-envremote-addr-returning-two-ips
-	 * The solution used is assuming that the last IP address is the external one.
+	 * The solution used is assuming that the first IP address is the external one (unless $useFirstIpInChain is set to false)
 	 *
 	 * @return  string
 	 */
 	protected static function detectAndCleanIP()
 	{
-		$ip = self::detectIP();
+		$ip = static::detectIP();
 
-		/**
-		 * If you have multiple IPs in the X-Forwarded-For header I will only ever use the FIRST one. See
-		 * https://en.wikipedia.org/wiki/X-Forwarded-For#Format for an explanation.
-		 */
 		if ((strstr($ip, ',') !== false) || (strstr($ip, ' ') !== false))
 		{
 			$ip = str_replace(' ', ',', $ip);
@@ -436,9 +432,10 @@ class Ip
 			$ips = explode(',', $ip);
 			$ip = '';
 
-			while (empty($ip) && !empty($ips))
+			// Loop until we're running out of parts or we have a hit
+			while ($ips)
 			{
-				$ip = array_pop($ips);
+				$ip = array_shift($ips);
 				$ip = trim($ip);
 
 				if (self::$useFirstIpInChain)


### PR DESCRIPTION
If the remote site uses a proxy server, the detected IP was wrong: the last IP in the chain was returned and not the first one, as defined by the specs https://en.wikipedia.org/wiki/X-Forwarded-For#Format

This PR fixes this