### PR TITLE
Fix tests due to vfsStream requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"require-dev": {
-		"mikey179/vfsStream": "dev-master",
+		"mikey179/vfsStream": "1.6.5||dev-master",
 		"phpunit/phpunit": "~4.8||~5.7",
 		"phpunit/dbunit": "~1.4||~2.0",
 		"mockery/mockery": "0.9.4||~0.9.5",


### PR DESCRIPTION
Note: This patch only fixes the Build errors, builds might still fail for other reasons (like some issue with mySQLi connection on travis).

`vfsStream` has set their `dev-master` to >PHP 7.1 so we need to Fall back to release `1.6.5` to remove build errors
Reference https://github.com/mikey179/vfsStream/issues/143

Note: they will be changing the package name at some point with the 2.x release
https://github.com/mikey179/vfsStream/issues/144