### PR TITLE
Add services to fix travis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ git:
 
 language: php
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0
@@ -18,8 +19,12 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7.3
     - php: 7.2
     - php: 7.1
+
+services:
+  - mysql
 
 branches:
   only:


### PR DESCRIPTION
Travis is throwing a `ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)` issue, this is fixed by forcing services to start mysql

also add php 7.3 since it's released