### PR TITLE
Refactored IP class to expose HTTP headers involved in proxies

### DIFF
--- a/fof/Utils/Ip.php
+++ b/fof/Utils/Ip.php
@@ -63,6 +63,16 @@ class Ip
 	}
 
 	/**
+	 * Getter for the list of proxy headers we can check
+	 *
+	 * @return array
+	 */
+	public static function getProxyHeaders()
+	{
+		return static::$proxyHeaders;
+	}
+
+	/**
 	 * Get the current visitor's IP address
 	 *
 	 * @return string

--- a/fof/Utils/Ip.php
+++ b/fof/Utils/Ip.php
@@ -42,6 +42,18 @@ class Ip
 	protected static $useFirstIpInChain = true;
 
 	/**
+	 * List of headers we should check to know if the user is behind a proxy. PLEASE NOTE: ORDER MATTERS!
+	 *
+	 * @var array
+	 */
+	protected static $proxyHeaders = [
+		'HTTP_CF_CONNECTING_IP',        // CloudFlare
+		'HTTP_X_FORWARDED_FOR',         // Standard for transparent proxy (e.g. NginX)
+		'HTTP_X_SUCURI_CLIENTIP',       // Sucuri firewall uses its own header
+		'HTTP_CLIENT_IP',               // Non-transparent proxy
+	];
+
+	/**
 	 * Set the $useFirstIpInChain flag. See above.
 	 *
 	 * @param   bool  $value


### PR DESCRIPTION
This PR moves the list of HTTP headers inside a class variable that could be exposed to the other objects.  
In this way other extensions can fetch the list of headers used to get the real IP.  

This PR is full B/C