### PR TITLE
CLI application will handle app messages, too

### DIFF
--- a/fof/Cli/Application.php
+++ b/fof/Cli/Application.php
@@ -172,6 +172,7 @@ include_once __DIR__ . '/Traits/CGIModeAware.php';
 include_once __DIR__ . '/Traits/CustomOptionsAware.php';
 include_once __DIR__ . '/Traits/JoomlaConfigAware.php';
 include_once __DIR__ . '/Traits/MemStatsAware.php';
+include_once __DIR__ . '/Traits/MessageAware.php';
 include_once __DIR__ . '/Traits/TimeAgoAware.php';
 
 // The actual implementation of the CliApplication depends on the Joomla version we're running under

--- a/fof/Cli/Joomla3.php
+++ b/fof/Cli/Joomla3.php
@@ -11,6 +11,7 @@ use FOF30\Cli\Traits\CGIModeAware;
 use FOF30\Cli\Traits\CustomOptionsAware;
 use FOF30\Cli\Traits\JoomlaConfigAware;
 use FOF30\Cli\Traits\MemStatsAware;
+use FOF30\Cli\Traits\MessageAware;
 use FOF30\Cli\Traits\TimeAgoAware;
 use FOF30\Utils\CliSessionHandler;
 use Joomla\CMS\Application\CliApplication;
@@ -32,7 +33,7 @@ if (@file_exists($cmsImportFilePath))
  */
 abstract class FOFCliApplicationJoomla3 extends CliApplication
 {
-	use CGIModeAware, CustomOptionsAware, JoomlaConfigAware, MemStatsAware, TimeAgoAware;
+	use CGIModeAware, CustomOptionsAware, JoomlaConfigAware, MemStatsAware, TimeAgoAware, MessageAware;
 
 	private $allowedToClose = false;
 
@@ -127,21 +128,6 @@ abstract class FOFCliApplicationJoomla3 extends CliApplication
 	 * @since   4.0.0
 	 */
 	public function getMenu($name = null, $options = [])
-	{
-		return null;
-	}
-
-	/**
-	 * Sometimes Joomla will try to enqueue messages even if we're under CLI, resulting in fatal errors since only the
-	 * web application has such method. This method will prevent failures, you may want to override it in your application
-	 * for further logging
-	 *
-	 * @param $message
-	 * @param $type
-	 *
-	 * @return null
-	 */
-	public function enqueueMessage($message, $type)
 	{
 		return null;
 	}

--- a/fof/Cli/Traits/MessageAware.php
+++ b/fof/Cli/Traits/MessageAware.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package   FOF
+ * @copyright Copyright (c)2010-2020 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 2, or later
+ */
+
+namespace FOF30\Cli\Traits;
+
+defined('_JEXEC') || die;
+
+/**
+ * Sometimes other extensions will try to enqueue messages to the application. Methods for those tasks only exists in
+ * web applications, so we have to replicate their behavior in CLI environment or fatal errors will occur
+ *
+ * @package FOF30\Cli\Traits
+ */
+trait MessageAware
+{
+	/** @var array Queue holding all messages */
+	protected $messageQueue = [];
+
+	/**
+	 * @param $msg
+	 * @param $type
+	 *
+	 * @return null
+	 */
+	public function enqueueMessage($msg, $type)
+	{
+		// Don't add empty messages.
+		if (trim($msg) === '')
+		{
+			return;
+		}
+
+		$message = ['message' => $msg, 'type' => strtolower($type)];
+
+		if (!in_array($message, $this->messageQueue))
+		{
+			// Enqueue the message.
+			$this->messageQueue[] = $message;
+		}
+	}
+
+	/**
+	 * Loosely based on Joomla getMessageQueue
+	 *
+	 * @param bool $clear
+	 *
+	 * @return array
+	 */
+	public function getMessageQueue($clear = false)
+	{
+		$messageQueue = $this->messageQueue;
+
+		if ($clear)
+		{
+			$this->messageQueue = [];
+		}
+
+		return $messageQueue;
+	}
+}


### PR DESCRIPTION
Several core extensions are relying on current Application to be able to handle system messages using the `enqueueMessage` and `getMessageQueue` methods.  
Sadly those methods are a _de facto_ requirement, but they are not declared in low level classes, so any other class extending the core ones `BaseApplication` or `CliApplication` will crash into a fatal error.  

This PR creates a new trait to make your CLI application aware of system messages; code is loosely based on Joomla one.  
This PR is fully B/C